### PR TITLE
Fix an issue with the deployment YAML template file.

### DIFF
--- a/kubernetes/falcon-deployment.yaml.ctmpl
+++ b/kubernetes/falcon-deployment.yaml.ctmpl
@@ -7,6 +7,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: falcon
   template:
     metadata:
       labels:


### PR DESCRIPTION
Without this `selector` field, the validation during the deployment process will fail due to an error:
```
error: error validating "falcon-deployment.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
```