### PR TITLE
Make Falcon cromwell query configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ A valid config.json file should look like:
 }
 ```
 
+To change the workflows that are started by Falcon, optionally specify a `cromwell_query_dict` in the `config.json`:
+```json
+{
+    "cromwell_query_dict": {
+        "status": "On Hold",
+        "label": {
+            "comment": "scale-test-workflow"
+        }
+    }
+}
+```
+
 **Note:** if you are using Cromwell-as-a-Service with falcon, besides the `config.json`, you also have to provide a valid service account key file `caas_key.json` under `falcon/falcon/config.json` (or change the `falcon-dev-compose.yml` accordingly).
 
 ### Build the docker image

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -66,10 +66,7 @@ class QueueHandler(object):
         self.settings = settings.get_settings(config_path)
         self.queue_update_interval = self.settings.get('queue_update_interval')
         self.cromwell_url = self.settings.get('cromwell_url')
-        self.cromwell_query_dict = {
-            'status': 'On Hold',
-            # 'additionalQueryResultFields': 'labels',  # TODO: uncomment this line when we need to de-dup workflows
-        }
+        self.cromwell_query_dict = self.settings.get('cromwell_query_dict')
 
     def spawn_and_start(self):
         """

--- a/falcon/settings.py
+++ b/falcon/settings.py
@@ -18,6 +18,7 @@ def get_settings(config_path):
             queue_update_interval (int): The sleep time between each time the queue handler retrieves
                 workflows from Cromwell.
             workflow_start_interval (int): The sleep time between each time the igniter starts a workflow in Cromwell.
+            cromwell_query_dict (dict): The query used for retrieving cromwell workflows
     """
     with open(config_path, 'r') as f:
         settings = json.load(f)
@@ -40,5 +41,11 @@ def get_settings(config_path):
     # Check other config parameters
     settings['queue_update_interval'] = int(settings.get('queue_update_interval', 1))
     settings['workflow_start_interval'] = int(settings.get('workflow_start_interval', 1))
+
+    # Check cromwell query parameters
+    query_dict = settings.get('cromwell_query_dict', {})
+    if ('status', 'On Hold') not in query_dict.items():
+        query_dict.update({'status': 'On Hold'})
+    settings['cromwell_query_dict'] = query_dict
 
     return settings

--- a/falcon/test/test_settings.py
+++ b/falcon/test/test_settings.py
@@ -31,6 +31,10 @@ class TestSettings(object):
         assert loaded_settings['workflow_start_interval'] == int(self.expected_settings_dic_cromwell_instance.get(
                 'workflow_start_interval'))
 
+    def test_get_settings_cromwell_query_dict_includes_on_hold_status(self):
+        loaded_settings = settings.get_settings('{0}{1}'.format(self.data_dir, self.cromwell_config))
+        assert loaded_settings['cromwell_query_dict']['status'] == 'On Hold'
+
     def test_get_settings_loads_config_file_for_caas_throw_exceptions_without_caas_key(self):
         with pytest.raises(ValueError):
             settings.get_settings('{0}{1}'.format(self.data_dir, self.caas_config))


### PR DESCRIPTION
Add the option to specify the `cromwell_query_dict` in the `config.json` file to change the default query that Falcon uses to get "On Hold" workflows. 

Addresses ticket: https://app.zenhub.com/workspace/o/humancellatlas/secondary-analysis/issues/235