### PR TITLE
Update cromwell tools version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Falcon comes with a light-weight Cromwell simulator, which provides a basic set 
 
 To run the simulation, you have to:
 
-1. Go to both `queue_handler.py` and `igniter.py` and replace the `from cromwell_tools import cromwell_tools` with `from falcon.test import cromwell_simulator as cromwell_tools` respectively.
+1. Go to both `queue_handler.py` and `igniter.py` and replace `from cromwell_tools.cromwell_api import CromwellAPI` with
+`from falcon.test import cromwell_simulator as CromwellAPI`.
 2. Start Falcon in develop mode, e.g. from the root of the repository:
     ```bash
     docker-compose -f falcon-dev-compose.yml up --build

--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -6,7 +6,6 @@ from threading import Thread, get_ident
 
 import requests
 from cromwell_tools.cromwell_api import CromwellAPI
-from cromwell_tools.cromwell_auth import CromwellAuth
 
 from falcon import queue_handler
 from falcon import settings
@@ -24,21 +23,8 @@ class Igniter(object):
         """
         self.thread = None
         self.settings = settings.get_settings(config_path)
-        self.cromwell_url = self.settings.get('cromwell_url')
+        self.cromwell_auth = settings.get_cromwell_auth(self.settings)
         self.workflow_start_interval = self.settings.get('workflow_start_interval')
-
-    @property
-    def cromwell_auth(self):
-        if self.settings.get('use_caas'):
-            return CromwellAuth.harmonize_credentials(
-                url=self.cromwell_url,
-                service_account_key=self.settings.get('caas_key')
-            )
-        return CromwellAuth.harmonize_credentials(
-            url=self.cromwell_url,
-            username=self.settings.get('cromwell_user'),
-            password=self.settings.get('cromwell_password')
-        )
 
     def spawn_and_start(self, handler):
         if not isinstance(handler, queue_handler.QueueHandler):

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -6,7 +6,6 @@ from threading import Thread, get_ident
 
 import requests
 from cromwell_tools.cromwell_api import CromwellAPI
-from cromwell_tools.cromwell_auth import CromwellAuth
 
 from falcon import settings
 
@@ -56,7 +55,6 @@ class QueueHandler(object):
         settings (dict): A dictionary contains all settings for the handler.
         queue_update_interval (int): This is the how long the handler will sleep for after each time it retrieves
             workflows from the Cromwell.
-        cromwell_url (str): This is the Cromwell url loaded from the settings.
         cromwell_query_dict (dict): This is the query dictionary handler uses for retrieving workflows from the
             Cromwell. Currently this is hard-coded.
     """
@@ -65,22 +63,9 @@ class QueueHandler(object):
         self.workflow_queue = self.create_empty_queue(-1)  # use infinite for the size of the queue for now
         self.thread = None
         self.settings = settings.get_settings(config_path)
+        self.cromwell_auth = settings.get_cromwell_auth(self.settings)
         self.queue_update_interval = self.settings.get('queue_update_interval')
-        self.cromwell_url = self.settings.get('cromwell_url')
         self.cromwell_query_dict = self.settings.get('cromwell_query_dict')
-
-    @property
-    def cromwell_auth(self):
-        if self.settings.get('use_caas'):
-            return CromwellAuth.harmonize_credentials(
-                url=self.cromwell_url,
-                service_account_key=self.settings.get('caas_key')
-            )
-        return CromwellAuth.harmonize_credentials(
-            url=self.cromwell_url,
-            username=self.settings.get('cromwell_user'),
-            password=self.settings.get('cromwell_password')
-        )
 
     def spawn_and_start(self):
         """

--- a/falcon/settings.py
+++ b/falcon/settings.py
@@ -1,5 +1,6 @@
 import json
 import os
+from cromwell_tools.cromwell_auth import CromwellAuth
 
 
 def get_settings(config_path):
@@ -49,3 +50,17 @@ def get_settings(config_path):
     settings['cromwell_query_dict'] = query_dict
 
     return settings
+
+
+def get_cromwell_auth(settings):
+    cromwell_url = settings.get('cromwell_url')
+    if settings.get('use_caas'):
+        return CromwellAuth.harmonize_credentials(
+            url=cromwell_url,
+            service_account_key=settings.get('caas_key')
+        )
+    return CromwellAuth.harmonize_credentials(
+        url=cromwell_url,
+        username=settings.get('cromwell_user'),
+        password=settings.get('cromwell_password')
+    )

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -54,9 +54,9 @@ def query_workflows_fail_with_500(query_dict, auth):
     return response
 
 
-def query_workflows(*args, **kwargs):
+def query(*args, **kwargs):
     """
-    Note: This function monkey-patches the `cromwell-tools.query_workflows()` for simulation purposes, DO NOT use this
+    Note: This function monkey-patches the `cromwell-tools.query()` for simulation purposes, DO NOT use this
     function is unit tests.
     """
     system_random = random.SystemRandom()
@@ -126,9 +126,9 @@ def release_workflow_with_500(uuid, auth):
     return response
 
 
-def release_workflow(*args, **kwargs):
+def release_hold(*args, **kwargs):
     """
-    Note: This function monkey-patches the `cromwell-tools.release_workflow()` for simulation purposes, DO NOT use this
+    Note: This function monkey-patches the `cromwell-tools.release_hold()` for simulation purposes, DO NOT use this
     function is unit tests.
     """
     system_random = random.SystemRandom()

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -7,23 +7,23 @@ import requests
 from requests.models import Response
 
 
-def query_workflows_raises_ConnectionError(cromwell_url, query_dict, cromwell_user, cromwell_password, caas_key):
+def query_workflows_raises_ConnectionError(query_dict, auth):
     raise requests.exceptions.ConnectionError
 
 
-def query_workflows_raises_RequestException(cromwell_url, query_dict, cromwell_user, cromwell_password, caas_key):
+def query_workflows_raises_RequestException(query_dict, auth):
     raise requests.exceptions.RequestException
 
 
-def release_workflow_raises_ConnectionError(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_raises_ConnectionError(uuid, auth):
     raise requests.exceptions.ConnectionError
 
 
-def release_workflow_raises_RequestException(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_raises_RequestException(uuid, auth):
     raise requests.exceptions.RequestException
 
 
-def query_workflows_succeed(cromwell_url, query_dict, cromwell_user, cromwell_password, caas_key):
+def query_workflows_succeed(query_dict, auth):
     response = Mock(spec=Response)
     response.status_code = 200
     response.json.return_value = {
@@ -36,7 +36,7 @@ def query_workflows_succeed(cromwell_url, query_dict, cromwell_user, cromwell_pa
     return response
 
 
-def query_workflows_fail_with_400(cromwell_url, query_dict, cromwell_user, cromwell_password, caas_key):
+def query_workflows_fail_with_400(query_dict, auth):
     response = Mock(spec=Response)
     response.status_code = 400
     response.json.return_value = {
@@ -47,7 +47,7 @@ def query_workflows_fail_with_400(cromwell_url, query_dict, cromwell_user, cromw
     return response
 
 
-def query_workflows_fail_with_500(cromwell_url, query_dict, cromwell_user, cromwell_password, caas_key):
+def query_workflows_fail_with_500(query_dict, auth):
     response = Mock(spec=Response)
     response.status_code = 500
     response.text = 'An error message for Internal Server Error.'
@@ -74,15 +74,15 @@ def query_workflows(*args, **kwargs):
     return query_func(*args, **kwargs)
 
 
-def release_workflow_succeed(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_succeed(uuid, auth):
     response = Mock(spec=Response)
     response.status_code = 200
-    response.json.return_value = {"id": workflow_id, "status": "Submitted"}
+    response.json.return_value = {"id": uuid, "status": "Submitted"}
     response.text = json.dumps(response.json.return_value)
     return response
 
 
-def release_workflow_with_400(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_with_400(uuid, auth):
     response = Mock(spec=Response)
     # TODO: figure out when can we get this type of error
     response.status_code = 400
@@ -94,32 +94,32 @@ def release_workflow_with_400(cromwell_url, workflow_id, cromwell_user, cromwell
     return response
 
 
-def release_workflow_with_403(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_with_403(uuid, auth):
     response = Mock(spec=Response)
     response.status_code = 403
     response.json.return_value = {
         'status' : 'error',
         'message': 'Couldn\'t change status of workflow {} to \'Submitted\' because the workflow'
-                   ' is not in \'On Hold\' state'.format(workflow_id)
+                   ' is not in \'On Hold\' state'.format(uuid)
     }
     response.text = json.dumps(response.json.return_value)
     return response
 
 
-def release_workflow_with_404(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_with_404(uuid, auth):
     response = Mock(spec=Response)
     # TODO: track on the issue: https://github.com/broadinstitute/cromwell/issues/3911, which causes the Cromwell
     # to return 500 code for 404 errors for now
     response.status_code = 404
     response.json.return_value = {
         'status' : 'fail',
-        'message': 'Unrecognized workflow ID: {}'.format(workflow_id)
+        'message': 'Unrecognized workflow ID: {}'.format(auth)
     }
     response.text = json.dumps(response.json.return_value)
     return response
 
 
-def release_workflow_with_500(cromwell_url, workflow_id, cromwell_user, cromwell_password, caas_key):
+def release_workflow_with_500(uuid, auth):
     response = Mock(spec=Response)
     response.status_code = 500
     response.text = 'An error message for Internal Server Error.'

--- a/falcon/test/test_handlers.py
+++ b/falcon/test/test_handlers.py
@@ -268,7 +268,7 @@ class TestQueueHandler(object):
         assert initial_queue_id != final_queue_id
         assert final_queue_id == another_queue_id
 
-    @patch('falcon.queue_handler.cromwell_tools.query_workflows', cromwell_simulator.query_workflows_succeed,
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_succeed,
            create=True)
     def test_retrieve_workflows_returns_query_results_successfully(self, caplog):
         """
@@ -286,7 +286,7 @@ class TestQueueHandler(object):
         assert num_workflows > 0
         assert 'Retrieved {0} workflows from Cromwell.'.format(num_workflows) in info
 
-    @patch('falcon.queue_handler.cromwell_tools.query_workflows', cromwell_simulator.query_workflows_fail_with_500,
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500,
            create=True)
     def test_retrieve_workflows_returns_none_for_500_response_code(self, caplog):
         """
@@ -302,7 +302,7 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in warn
 
-    @patch('falcon.queue_handler.cromwell_tools.query_workflows', cromwell_simulator.query_workflows_fail_with_400,
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_400,
            create=True)
     def test_retrieve_workflows_returns_none_for_400_response_code(self, caplog):
         """
@@ -318,7 +318,7 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in warn
 
-    @patch('falcon.queue_handler.cromwell_tools.query_workflows',
+    @patch('falcon.queue_handler.CromwellAPI.query',
            cromwell_simulator.query_workflows_raises_ConnectionError,
            create=True)
     def test_retrieve_workflows_returns_none_for_connection_error(self, caplog):
@@ -335,7 +335,7 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in error
 
-    @patch('falcon.queue_handler.cromwell_tools.query_workflows',
+    @patch('falcon.queue_handler.CromwellAPI.query',
            cromwell_simulator.query_workflows_raises_RequestException,
            create=True)
     def test_retrieve_workflows_returns_none_for_400_requests_exception(self, caplog):
@@ -385,7 +385,7 @@ class TestQueueHandler(object):
             assert item.id == expect_result[idx]
 
     @pytest.mark.timeout(2)
-    @patch('falcon.queue_handler.cromwell_tools.query_workflows', cromwell_simulator.query_workflows_fail_with_500,
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500,
            create=True)
     def test_execution_event_goes_back_to_sleep_directly_when_it_fails_to_retrieve_workflows(self, caplog):
         """

--- a/falcon/test/test_igniters.py
+++ b/falcon/test/test_igniters.py
@@ -102,7 +102,7 @@ class TestIgniter(object):
 
         assert 'The thread of this igniter is not in a running state.' in error
 
-    @patch('falcon.igniter.cromwell_tools.release_workflow', cromwell_simulator.release_workflow_succeed, create=True)
+    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_succeed, create=True)
     def test_release_workflow_successfully_releases_a_workflow(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 200 OK from the Cromwell.
@@ -116,7 +116,7 @@ class TestIgniter(object):
 
         assert 'Released a workflow fake_workflow_id' in info
 
-    @patch('falcon.igniter.cromwell_tools.release_workflow', cromwell_simulator.release_workflow_with_403, create=True)
+    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_with_403, create=True)
     def test_release_workflow_handles_403_response_code(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 403 error from the
@@ -131,7 +131,7 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in warn
 
-    @patch('falcon.igniter.cromwell_tools.release_workflow', cromwell_simulator.release_workflow_with_404, create=True)
+    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_with_404, create=True)
     def test_release_workflow_handles_404_response_code(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 404 error from the
@@ -146,7 +146,7 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in warn
 
-    @patch('falcon.igniter.cromwell_tools.release_workflow', cromwell_simulator.release_workflow_with_500, create=True)
+    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_with_500, create=True)
     def test_release_workflow_handles_500_response_code(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 500 error from the
@@ -161,7 +161,7 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in warn
 
-    @patch('falcon.igniter.cromwell_tools.release_workflow', cromwell_simulator.release_workflow_raises_ConnectionError,
+    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_raises_ConnectionError,
            create=True)
     def test_release_workflow_handles_connection_error(self, caplog):
         """
@@ -177,7 +177,7 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in error
 
-    @patch('falcon.igniter.cromwell_tools.release_workflow',
+    @patch('falcon.igniter.CromwellAPI.release_hold',
            cromwell_simulator.release_workflow_raises_RequestException, create=True)
     def test_release_workflow_handles_requests_exception(self, caplog):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/broadinstitute/cromwell-tools.git@v0.5.0
+git+git://github.com/broadinstitute/cromwell-tools.git@v1.1.1
 pytest==3.6.3
 pytest-timeout==1.3.1
 pytest-cov==2.5.1


### PR DESCRIPTION
Purpose
--------
Fixes https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-63

Changes
---------
Use latest version of cromwell-tools, which went through a significant refactor since this Falcon code was written 

Review/QA instructions:
-----------------------
1. Run Falcon locally using caas-prod:
a. Checkout this branch locally and change the `cromwell_url` in `config.json` to `https://cromwell.caas-prod.broadinstitute.org`
b. Run falcon: `docker-compose -f falcon-dev-compose.yml up --build`
c. Submit a few test workflows in "On Hold" status. These can be basic "Hello World" wdls.
d. Check the falcon logs to see if the QueueHandler can retrieve workflows without any errors. Look for `Retrieved <number of on-hold workflows> workflows from Cromwell.`
e. Check the falcon logs to see if the Igniter can start a workflow. Look for `Released a workflow <workflow_id>`

2. Repeat with Falcon using a Cromwell instance that uses username/password auth, such as `https://cromwell.mint-dev.broadinstitute.org`

3. Test the cromwell simulator by following the instructions from the README: https://github.com/HumanCellAtlas/falcon/blob/2b397e0ed2ae42fa2454cfded153a1acab6bd8fb/README.md#simulation

Notes
------
When re-deploying falcon the cromwell-url needs to be updated as well:
E.g. `https://cromwell.caas-prod.broadinstitute.org` instead of `https://cromwell.caas-prod.broadinstitute.org/api/workflows/v1`