### PR TITLE
Update example config.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ modify the `falcon-dev-compose.yml` file to locate where the `config.json` is.
 A valid config.json file should look like:
 ```json
 {
-    "cromwell_url": "https://your.cromwell.domain.here/api/workflows/v1",
+    "cromwell_url": "https://your.cromwell.domain.here",
     "use_caas": false,
     "cromwell_user": "test",
     "cromwell_password": "test",


### PR DESCRIPTION
Update the `cromwell_url` in the example config.json, since falcon will now pass in only the cromwell base url to cromwell tools.