### PR TITLE
Add formatter and linting test to Falcon

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,18 @@
 [flake8]
 ignore = E203, E266, E501, W503
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
+max-complexity = 18  # Set the maximum allowed McCabe complexity value for a block of code.
+select = B,C,E,F,W,T4,B9  # Specify the list of error codes we wish Flake8 to report.
+
+
+# We ignore the following PEP-8 styles:
+# 
+# 
+# E203	whitespace before ‘:’
+# E266	too many leading ‘#’ for block comment
+# E501 (^)	line too long (82 > 79 characters)
+# W503	line break occurred before a binary operator
+# 
+# 
+# Note: (^) These checks can be disabled at the 
+# line level using the # noqa special comment. 
+# This possibility should be reserved for special cases.

--- a/.flake8
+++ b/.flake8
@@ -1,18 +1,15 @@
-[flake8]
-ignore = E203, E266, E501, W503
-max-complexity = 18  # Set the maximum allowed McCabe complexity value for a block of code.
-select = B,C,E,F,W,T4,B9  # Specify the list of error codes we wish Flake8 to report.
-
-
 # We ignore the following PEP-8 styles:
-# 
-# 
+
 # E203	whitespace before ‘:’
 # E266	too many leading ‘#’ for block comment
 # E501 (^)	line too long (82 > 79 characters)
 # W503	line break occurred before a binary operator
-# 
-# 
+
 # Note: (^) These checks can be disabled at the 
 # line level using the # noqa special comment. 
 # This possibility should be reserved for special cases.
+
+[flake8]
+ignore = E203, E266, E501, W503
+max-complexity = 18  # Set the maximum allowed McCabe complexity value for a block of code.
+select = B,C,E,F,W,T4,B9  # Specify the list of error codes we wish Flake8 to report.

--- a/.flake8
+++ b/.flake8
@@ -11,5 +11,5 @@
 
 [flake8]
 ignore = E203, E266, E501, W503
-max-complexity = 18  # Set the maximum allowed McCabe complexity value for a block of code.
-select = B,C,E,F,W,T4,B9  # Specify the list of error codes we wish Flake8 to report.
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.3b0
     hooks:
     - id: black
       language_version: python3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.6
+      # Using args here is not recommended by Black: 
+      # https://black.readthedocs.io/en/stable/version_control_integration.html
+      # But since we only have one argument here, and 
+      # we don't force developers to use editor plugins,
+      # putting the args here seems to be fine 
+      args: [--skip-string-normalization]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
+language: python
+
+python: 
+  - '3.6'
+
 jobs:
   include:
     - stage: Linting Test
-      language: python
-      python: 
-      - '3.6'
       install: "pip install -r requirements.txt"
       script: flake8 falcon/
 
     - stage: Unit Test
-      language: python
-      python:
-      - '3.6'
       sudo: required
       services: docker
       script: cd falcon/test && bash test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ python:
 
 jobs:
   include:
+    # The linting test is fast and cheap so run it first
     - stage: Linting Test
       install: "pip install -r requirements.txt"
-      script: flake8 falcon/
+      script: 
+        # Check Black code style compliance
+        - black falcon/ --skip-string-normalization --check
+        # Check PEP-8 compliance
+        - flake8 falcon/
 
+    # The unit test is a bit more expensive so run it only
+    # if the linting test passes
     - stage: Unit Test
       sudo: required
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
-language: python
-python:
-- '3.6'
-sudo: required
-services: docker
-script: cd falcon/test && bash test.sh
+jobs:
+  include:
+    - stage: Linting Test
+      language: python
+      python: 
+      - '3.6'
+      install: "pip install -r requirements.txt"
+      script: flake8 falcon/
+
+    - stage: Unit Test
+      language: python
+      python:
+      - '3.6'
+      sudo: required
+      services: docker
+      script: cd falcon/test && bash test.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Falcon
 
-[![Build Status](https://travis-ci.com/HumanCellAtlas/falcon.svg?branch=master)](https://travis-ci.com/HumanCellAtlas/falcon)
+[![Travis (.com)](https://img.shields.io/travis/com/HumanCellAtlas/falcon.svg?label=Unit%20Test%20on%20Travis%20CI%20&style=flat-square)](https://travis-ci.com/HumanCellAtlas/falcon)
 [![Docker Repository on Quay](https://quay.io/repository/humancellatlas/secondary-analysis-falcon/status "Docker Repository on Quay")](https://quay.io/repository/humancellatlas/secondary-analysis-falcon)
+[![GitHub Release](https://img.shields.io/github/release/HumanCellAtlas/falcon.svg?label=Latest%20Release&style=flat-square&colorB=green)](https://github.com/HumanCellAtlas/falcon/releases)
+![Python Version](https://img.shields.io/badge/Python-3.6%20%7C%203.7-green.svg?style=flat-square&logo=python&colorB=blue)
+[![License](https://img.shields.io/github/license/HumanCellAtlas/falcon.svg?style=flat-square)](https://github.com/HumanCellAtlas/falcon/blob/master/LICENSE)
+[![Code style: black](https://img.shields.io/badge/Code%20Style-black-000000.svg?style=flat-square)](https://github.com/ambv/black)
 
 The workflow starter of secondary analysis service.
 
@@ -9,6 +13,18 @@ Falcon is currently implemented following a semi single-producer-single/multiple
 
 
 ## Development
+
+### Code Style
+
+The Falcon code base is complying with the PEP-8 and using [Black](https://github.com/ambv/black) to 
+format our code, in order to avoid "nitpicky" comments during the code review process so we spend more
+time discussing about the logic, not code styles.
+
+In order to enable the auto-formatting in the development process, you have to spend a few seconds setting up the `pre-commit` the first time you clone the repo:
+
+1. Install pre-commit and black: `pip install pre-commit black` (or simply `pip install -r requirements.txt`).
+2. Make sure the `.pre-commit-config.yaml` still looks OK to you.
+3. Run `pre-commit install` to install the git hook.
 
 ### Configuration
 To make the falcon work properly, you have to either create a `config.json` under `falcon/falcon/config.json`, or

--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ Falcon is currently implemented following a semi single-producer-single/multiple
 ### Code Style
 
 The Falcon code base is complying with the PEP-8 and using [Black](https://github.com/ambv/black) to 
-format our code, in order to avoid "nitpicky" comments during the code review process so we spend more
-time discussing about the logic, not code styles.
+format our code, in order to avoid "nitpicky" comments during the code review process so we spend more time discussing about the logic, not code styles.
 
 In order to enable the auto-formatting in the development process, you have to spend a few seconds setting up the `pre-commit` the first time you clone the repo:
 
-1. Install pre-commit and black: `pip install pre-commit black` (or simply `pip install -r requirements.txt`).
+1. Install pre-commit and black: `pip install pre-commit black` (or simply run `pip install -r requirements.txt`). _Make sure you install the same versions of `Black` and `pre-commit` as those listed in the `requirements.txt`._
 2. Make sure the `.pre-commit-config.yaml` still looks OK to you.
 3. Run `pre-commit install` to install the git hook.
+
+Please make sure you followed the above steps, otherwise your commits might fail at the linting test!
 
 ### Configuration
 To make the falcon work properly, you have to either create a `config.json` under `falcon/falcon/config.json`, or

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ format our code, in order to avoid "nitpicky" comments during the code review pr
 
 In order to enable the auto-formatting in the development process, you have to spend a few seconds setting up the `pre-commit` the first time you clone the repo:
 
-1. Install pre-commit and black: `pip install pre-commit black` (or simply run `pip install -r requirements.txt`). _Make sure you install the same versions of `Black` and `pre-commit` as those listed in the `requirements.txt`._
+1. Install `pre-commit` by running: `pip install pre-commit` (or simply run `pip install -r requirements.txt`).
 2. Make sure the `.pre-commit-config.yaml` still looks OK to you.
 3. Run `pre-commit install` to install the git hook.
 

--- a/falcon/__main__.py
+++ b/falcon/__main__.py
@@ -9,7 +9,9 @@ if __name__ == '__main__':
     igniter = Igniter(config_path)  # instantiate a concrete `Igniter`
 
     handler.spawn_and_start()  # start the thread within the handler
-    igniter.spawn_and_start(handler)  # start the thread within the igniter by passing the handler into it
+    igniter.spawn_and_start(
+        handler
+    )  # start the thread within the igniter by passing the handler into it
 
     # without monitoring the health of the 2 processes, these joins are trivial
     handler.join()

--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -28,11 +28,15 @@ class Igniter(object):
 
     def spawn_and_start(self, handler):
         if not isinstance(handler, queue_handler.QueueHandler):
-            raise TypeError('Igniter has to access to an instance of the QueueHandler to start!')
+            raise TypeError(
+                'Igniter has to access to an instance of the QueueHandler to start!'
+            )
 
         if not self.thread:
             # TODO: by appending an uuid to the thread name, we can have multiple igniter threads here in the future
-            self.thread = Thread(target=self.execution_loop, name='igniter', args=(handler,))
+            self.thread = Thread(
+                target=self.execution_loop, name='igniter', args=(handler,)
+            )
         self.thread.start()
 
     def join(self):
@@ -42,12 +46,20 @@ class Igniter(object):
             logger.error('The thread of this igniter is not in a running state.')
 
     def execution_loop(self, handler):
-        logger.info('Igniter | Initializing an igniter with thread ID => {0} | {1}'.format(get_ident(), datetime.now()))
+        logger.info(
+            'Igniter | Initializing an igniter with thread ID => {0} | {1}'.format(
+                get_ident(), datetime.now()
+            )
+        )
         while True:
             self.execution_event(handler)
 
     def execution_event(self, handler):
-        logger.info('Igniter | Igniter thread {0} is warmed up and running. | {1}'.format(get_ident(), datetime.now()))
+        logger.info(
+            'Igniter | Igniter thread {0} is warmed up and running. | {1}'.format(
+                get_ident(), datetime.now()
+            )
+        )
         try:
             workflow = handler.workflow_queue.get(block=False)
             self.release_workflow(workflow)
@@ -61,7 +73,9 @@ class Igniter(object):
 
     def release_workflow(self, workflow):
         try:
-            response = CromwellAPI.release_hold(uuid=workflow.id, auth=self.cromwell_auth)
+            response = CromwellAPI.release_hold(
+                uuid=workflow.id, auth=self.cromwell_auth
+            )
             if response.status_code != 200:
                 logger.warning(
                     'Igniter | Failed to release a workflow {0} | {1} | {2}'.format(
@@ -69,10 +83,19 @@ class Igniter(object):
                     )
                 )
             else:
-                logger.info('Igniter | Released a workflow {0} | {1}'.format(workflow, datetime.now()))
-        except (requests.exceptions.ConnectionError, requests.exceptions.RequestException) as error:
+                logger.info(
+                    'Igniter | Released a workflow {0} | {1}'.format(
+                        workflow, datetime.now()
+                    )
+                )
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
+        ) as error:
             logger.error(
-                'Igniter | Failed to release a workflow {0}| {1} | {2}'.format(workflow, error, datetime.now())
+                'Igniter | Failed to release a workflow {0}| {1} | {2}'.format(
+                    workflow, error, datetime.now()
+                )
             )
 
     @staticmethod

--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -53,26 +53,27 @@ class Igniter(object):
             self.release_workflow(workflow)
         except queue.Empty:
             logger.info(
-                    'Igniter | The in-memory queue is empty, go back to sleep and wait for the handler to retrieve '
-                    'workflows. | {0}'.format(
-                            datetime.now()))
+                'Igniter | The in-memory queue is empty, go back to sleep and wait for the handler to retrieve '
+                'workflows. | {0}'.format(datetime.now())
+            )
         finally:
             self.sleep_for(self.workflow_start_interval)
 
     def release_workflow(self, workflow):
         try:
-            response = CromwellAPI.release_hold(
-                    uuid=workflow.id,
-                    auth=self.cromwell_auth,
-            )
+            response = CromwellAPI.release_hold(uuid=workflow.id, auth=self.cromwell_auth)
             if response.status_code != 200:
                 logger.warning(
-                        'Igniter | Failed to release a workflow {0} | {1} | {2}'.format(workflow, response.text,
-                                                                                        datetime.now()))
+                    'Igniter | Failed to release a workflow {0} | {1} | {2}'.format(
+                        workflow, response.text, datetime.now()
+                    )
+                )
             else:
                 logger.info('Igniter | Released a workflow {0} | {1}'.format(workflow, datetime.now()))
         except (requests.exceptions.ConnectionError, requests.exceptions.RequestException) as error:
-            logger.error('Igniter | Failed to release a workflow {0}| {1} | {2}'.format(workflow, error, datetime.now()))
+            logger.error(
+                'Igniter | Failed to release a workflow {0}| {1} | {2}'.format(workflow, error, datetime.now())
+            )
 
     @staticmethod
     def sleep_for(sleep_time):

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -86,13 +86,15 @@ class QueueHandler(object):
 
     def execution_loop(self):
         logger.info(
-                'QueueHandler | Initializing the queue handler with thread => {0} | {1}'.format(get_ident(),
-                                                                                                datetime.now()))
+            'QueueHandler | Initializing the queue handler with thread => {0} | {1}'.format(get_ident(), datetime.now())
+        )
         while True:
             self.execution_event()
 
     def execution_event(self):
-        logger.info('QueueHandler | QueueHandler thread {0} is warmed up and running. | {1}'.format(get_ident(), datetime.now()))
+        logger.info(
+            'QueueHandler | QueueHandler thread {0} is warmed up and running. | {1}'.format(get_ident(), datetime.now())
+        )
         workflow_metas = self.retrieve_workflows(self.cromwell_query_dict)
         if workflow_metas:  # This could happen when getting either non-200 codes or 0 workflow from Cromwell
             workflows = self.prepare_workflows(workflow_metas)
@@ -103,9 +105,8 @@ class QueueHandler(object):
             self.enqueue(workflows)
         else:
             logger.info(
-                    'QueueHandler | Cannot fetch any workflow from Cromwell, go back to sleep and wait for next '
-                    'attempt. | {0}'
-                        .format(datetime.now())
+                'QueueHandler | Cannot fetch any workflow from Cromwell, go back to sleep and wait for next '
+                'attempt. | {0}'.format(datetime.now())
             )
         self.sleep_for(self.queue_update_interval)
 
@@ -142,23 +143,26 @@ class QueueHandler(object):
         """
         workflow_metas = None
         try:
-            response = CromwellAPI.query(
-                    auth=self.cromwell_auth,
-                    query_dict=query_dict,
-            )
+            response = CromwellAPI.query(auth=self.cromwell_auth, query_dict=query_dict)
             if response.status_code != 200:
                 logger.warning(
-                    'QueueHandler | Failed to retrieve workflows from Cromwell | {0} | {1}'.format(response.text,
-                                                                                                   datetime.now()))
+                    'QueueHandler | Failed to retrieve workflows from Cromwell | {0} | {1}'.format(
+                        response.text, datetime.now()
+                    )
+                )
             else:
                 workflow_metas = response.json()['results']
                 num_workflows = len(workflow_metas)
                 logger.info(
-                    'QueueHandler | Retrieved {0} workflows from Cromwell. | {1}'.format(num_workflows, datetime.now()))
+                    'QueueHandler | Retrieved {0} workflows from Cromwell. | {1}'.format(num_workflows, datetime.now())
+                )
                 logger.debug(
-                    'QueueHandler | {0} | {1}'.format(workflow_metas, datetime.now()))  # TODO: remove this or not?
+                    'QueueHandler | {0} | {1}'.format(workflow_metas, datetime.now())
+                )  # TODO: remove this or not?
         except (requests.exceptions.ConnectionError, requests.exceptions.RequestException) as error:
-            logger.error('QueueHandler | Failed to retrieve workflows from Cromwell | {0} | {1}'.format(error, datetime.now()))
+            logger.error(
+                'QueueHandler | Failed to retrieve workflows from Cromwell | {0} | {1}'.format(error, datetime.now())
+            )
         finally:
             return workflow_metas
 
@@ -309,9 +313,10 @@ class QueueHandler(object):
             return head <= tail
         except ValueError:
             logger.error(
-                    'Queue | An error happened when try to parse the submission timestamps, will assume oldest first '
-                    'for'
-                    ' the workflows returned from Cromwell | {0}'.format(datetime.now()))
+                'Queue | An error happened when try to parse the submission timestamps, will assume oldest first '
+                'for'
+                ' the workflows returned from Cromwell | {0}'.format(datetime.now())
+            )
             return True
 
     @staticmethod

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -60,7 +60,9 @@ class QueueHandler(object):
     """
 
     def __init__(self, config_path):
-        self.workflow_queue = self.create_empty_queue(-1)  # use infinite for the size of the queue for now
+        self.workflow_queue = self.create_empty_queue(
+            -1
+        )  # use infinite for the size of the queue for now
         self.thread = None
         self.settings = settings.get_settings(config_path)
         self.cromwell_auth = settings.get_cromwell_auth(self.settings)
@@ -86,17 +88,23 @@ class QueueHandler(object):
 
     def execution_loop(self):
         logger.info(
-            'QueueHandler | Initializing the queue handler with thread => {0} | {1}'.format(get_ident(), datetime.now())
+            'QueueHandler | Initializing the queue handler with thread => {0} | {1}'.format(
+                get_ident(), datetime.now()
+            )
         )
         while True:
             self.execution_event()
 
     def execution_event(self):
         logger.info(
-            'QueueHandler | QueueHandler thread {0} is warmed up and running. | {1}'.format(get_ident(), datetime.now())
+            'QueueHandler | QueueHandler thread {0} is warmed up and running. | {1}'.format(
+                get_ident(), datetime.now()
+            )
         )
         workflow_metas = self.retrieve_workflows(self.cromwell_query_dict)
-        if workflow_metas:  # This could happen when getting either non-200 codes or 0 workflow from Cromwell
+        if (
+            workflow_metas
+        ):  # This could happen when getting either non-200 codes or 0 workflow from Cromwell
             workflows = self.prepare_workflows(workflow_metas)
 
             # This must happen before `enqueue()` is called, so that each time the queue is refreshed and updated
@@ -154,14 +162,21 @@ class QueueHandler(object):
                 workflow_metas = response.json()['results']
                 num_workflows = len(workflow_metas)
                 logger.info(
-                    'QueueHandler | Retrieved {0} workflows from Cromwell. | {1}'.format(num_workflows, datetime.now())
+                    'QueueHandler | Retrieved {0} workflows from Cromwell. | {1}'.format(
+                        num_workflows, datetime.now()
+                    )
                 )
                 logger.debug(
                     'QueueHandler | {0} | {1}'.format(workflow_metas, datetime.now())
                 )  # TODO: remove this or not?
-        except (requests.exceptions.ConnectionError, requests.exceptions.RequestException) as error:
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
+        ) as error:
             logger.error(
-                'QueueHandler | Failed to retrieve workflows from Cromwell | {0} | {1}'.format(error, datetime.now())
+                'QueueHandler | Failed to retrieve workflows from Cromwell | {0} | {1}'.format(
+                    error, datetime.now()
+                )
             )
         finally:
             return workflow_metas
@@ -212,8 +227,14 @@ class QueueHandler(object):
             to be put in the in-memory queue.
         """
         for workflow in workflows:
-            logger.debug('QueueHandler | Enqueuing workflow {0} | {1}'.format(workflow, datetime.now()))
-            self.workflow_queue.put(workflow)  # TODO: Implement and add de-duplication logic here
+            logger.debug(
+                'QueueHandler | Enqueuing workflow {0} | {1}'.format(
+                    workflow, datetime.now()
+                )
+            )
+            self.workflow_queue.put(
+                workflow
+            )  # TODO: Implement and add de-duplication logic here
 
     def set_queue(self, queue):
         """
@@ -266,9 +287,19 @@ class QueueHandler(object):
             Workflow: A concrete `Workflow` instance that has necessary properties.
         """
         workflow_id = workflow_meta.get('id')
-        workflow_labels = workflow_meta.get('labels')  # TODO: Integrate this field into Workflow class
-        workflow_bundle_uuid = workflow_labels.get('bundle-uuid') if isinstance(workflow_labels, dict) else None
-        workflow_bundle_version = workflow_labels.get('bundle-version') if isinstance(workflow_labels, dict) else None
+        workflow_labels = workflow_meta.get(
+            'labels'
+        )  # TODO: Integrate this field into Workflow class
+        workflow_bundle_uuid = (
+            workflow_labels.get('bundle-uuid')
+            if isinstance(workflow_labels, dict)
+            else None
+        )
+        workflow_bundle_version = (
+            workflow_labels.get('bundle-version')
+            if isinstance(workflow_labels, dict)
+            else None
+        )
         workflow = Workflow(workflow_id, workflow_bundle_uuid, workflow_bundle_version)
         return workflow
 
@@ -308,8 +339,12 @@ class QueueHandler(object):
         """
         CROMWELL_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
         try:
-            head = datetime.strptime(str(workflow_list[0].get('submission')), CROMWELL_DATETIME_FORMAT)
-            tail = datetime.strptime(str(workflow_list[-1].get('submission')), CROMWELL_DATETIME_FORMAT)
+            head = datetime.strptime(
+                str(workflow_list[0].get('submission')), CROMWELL_DATETIME_FORMAT
+            )
+            tail = datetime.strptime(
+                str(workflow_list[-1].get('submission')), CROMWELL_DATETIME_FORMAT
+            )
             return head <= tail
         except ValueError:
             logger.error(

--- a/falcon/settings.py
+++ b/falcon/settings.py
@@ -31,17 +31,23 @@ def get_settings(config_path):
     # Check auth parameters
     if settings['use_caas']:
         if not settings['collection_name']:
-            raise ValueError('To use the Cromwell-as-a-Service, you have to pass in a valid collection name.')
+            raise ValueError(
+                'To use the Cromwell-as-a-Service, you have to pass in a valid collection name.'
+            )
 
         caas_key = os.environ.get('caas_key') or os.environ.get('CAAS_KEY')
         if not caas_key:
-            raise ValueError('No service account json key provided for cromwell-as-a-service.')
+            raise ValueError(
+                'No service account json key provided for cromwell-as-a-service.'
+            )
         else:
             settings['caas_key'] = caas_key
 
     # Check other config parameters
     settings['queue_update_interval'] = int(settings.get('queue_update_interval', 1))
-    settings['workflow_start_interval'] = int(settings.get('workflow_start_interval', 1))
+    settings['workflow_start_interval'] = int(
+        settings.get('workflow_start_interval', 1)
+    )
 
     # Check cromwell query parameters
     query_dict = settings.get('cromwell_query_dict', {})
@@ -55,7 +61,11 @@ def get_settings(config_path):
 def get_cromwell_auth(settings):
     cromwell_url = settings.get('cromwell_url')
     if settings.get('use_caas'):
-        return CromwellAuth.harmonize_credentials(url=cromwell_url, service_account_key=settings.get('caas_key'))
+        return CromwellAuth.harmonize_credentials(
+            url=cromwell_url, service_account_key=settings.get('caas_key')
+        )
     return CromwellAuth.harmonize_credentials(
-        url=cromwell_url, username=settings.get('cromwell_user'), password=settings.get('cromwell_password')
+        url=cromwell_url,
+        username=settings.get('cromwell_user'),
+        password=settings.get('cromwell_password'),
     )

--- a/falcon/settings.py
+++ b/falcon/settings.py
@@ -55,12 +55,7 @@ def get_settings(config_path):
 def get_cromwell_auth(settings):
     cromwell_url = settings.get('cromwell_url')
     if settings.get('use_caas'):
-        return CromwellAuth.harmonize_credentials(
-            url=cromwell_url,
-            service_account_key=settings.get('caas_key')
-        )
+        return CromwellAuth.harmonize_credentials(url=cromwell_url, service_account_key=settings.get('caas_key'))
     return CromwellAuth.harmonize_credentials(
-        url=cromwell_url,
-        username=settings.get('cromwell_user'),
-        password=settings.get('cromwell_password')
+        url=cromwell_url, username=settings.get('cromwell_user'), password=settings.get('cromwell_password')
     )

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -28,9 +28,7 @@ def query_workflows_succeed(query_dict, auth):
     response.status_code = 200
     response.json.return_value = {
         'results': [
-            {
-                'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'
-            } for i in range(random.randint(1, 10))
+            {'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'} for i in range(random.randint(1, 10))
         ]
     }
     return response
@@ -39,10 +37,7 @@ def query_workflows_succeed(query_dict, auth):
 def query_workflows_fail_with_400(query_dict, auth):
     response = Mock(spec=Response)
     response.status_code = 400
-    response.json.return_value = {
-        'status' : 'fail',
-        'message': 'An error message for Malformed Request.'
-    }
+    response.json.return_value = {'status': 'fail', 'message': 'An error message for Malformed Request.'}
     response.text = json.dumps(response.json.return_value)
     return response
 
@@ -68,9 +63,7 @@ def query(*args, **kwargs):
 
     # Make the possibilities of getting the status codes 200:400:500 as 20:1:1 in the simulation
     # There are also 1/12 probabilities the simulator will intentionally throw out some connection issues
-    query_func = system_random.choice(
-            candidate_func_list
-    )
+    query_func = system_random.choice(candidate_func_list)
     return query_func(*args, **kwargs)
 
 
@@ -86,10 +79,7 @@ def release_workflow_with_400(uuid, auth):
     response = Mock(spec=Response)
     # TODO: figure out when can we get this type of error
     response.status_code = 400
-    response.json.return_value = {
-        'status' : 'fail',
-        'message': 'An error message for Malformed Request.'
-    }
+    response.json.return_value = {'status': 'fail', 'message': 'An error message for Malformed Request.'}
     response.text = json.dumps(response.json.return_value)
     return response
 
@@ -98,9 +88,9 @@ def release_workflow_with_403(uuid, auth):
     response = Mock(spec=Response)
     response.status_code = 403
     response.json.return_value = {
-        'status' : 'error',
+        'status': 'error',
         'message': 'Couldn\'t change status of workflow {} to \'Submitted\' because the workflow'
-                   ' is not in \'On Hold\' state'.format(uuid)
+        ' is not in \'On Hold\' state'.format(uuid),
     }
     response.text = json.dumps(response.json.return_value)
     return response
@@ -111,10 +101,7 @@ def release_workflow_with_404(uuid, auth):
     # TODO: track on the issue: https://github.com/broadinstitute/cromwell/issues/3911, which causes the Cromwell
     # to return 500 code for 404 errors for now
     response.status_code = 404
-    response.json.return_value = {
-        'status' : 'fail',
-        'message': 'Unrecognized workflow ID: {}'.format(auth)
-    }
+    response.json.return_value = {'status': 'fail', 'message': 'Unrecognized workflow ID: {}'.format(auth)}
     response.text = json.dumps(response.json.return_value)
     return response
 
@@ -142,7 +129,5 @@ def release_hold(*args, **kwargs):
 
     # Make the possibilities of getting the status codes 200:400:403:404:500 as 20:1:1:1:1 in the simulation
     # There are also 1/13 probabilities the simulator will intentionally throw out some connection issues
-    release_func = system_random.choice(
-            candidate_func_list
-    )
+    release_func = system_random.choice(candidate_func_list)
     return release_func(*args, **kwargs)

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -28,7 +28,8 @@ def query_workflows_succeed(query_dict, auth):
     response.status_code = 200
     response.json.return_value = {
         'results': [
-            {'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'} for i in range(random.randint(1, 10))
+            {'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'}
+            for i in range(random.randint(1, 10))
         ]
     }
     return response
@@ -37,7 +38,10 @@ def query_workflows_succeed(query_dict, auth):
 def query_workflows_fail_with_400(query_dict, auth):
     response = Mock(spec=Response)
     response.status_code = 400
-    response.json.return_value = {'status': 'fail', 'message': 'An error message for Malformed Request.'}
+    response.json.return_value = {
+        'status': 'fail',
+        'message': 'An error message for Malformed Request.',
+    }
     response.text = json.dumps(response.json.return_value)
     return response
 
@@ -79,7 +83,10 @@ def release_workflow_with_400(uuid, auth):
     response = Mock(spec=Response)
     # TODO: figure out when can we get this type of error
     response.status_code = 400
-    response.json.return_value = {'status': 'fail', 'message': 'An error message for Malformed Request.'}
+    response.json.return_value = {
+        'status': 'fail',
+        'message': 'An error message for Malformed Request.',
+    }
     response.text = json.dumps(response.json.return_value)
     return response
 
@@ -101,7 +108,10 @@ def release_workflow_with_404(uuid, auth):
     # TODO: track on the issue: https://github.com/broadinstitute/cromwell/issues/3911, which causes the Cromwell
     # to return 500 code for 404 errors for now
     response.status_code = 404
-    response.json.return_value = {'status': 'fail', 'message': 'Unrecognized workflow ID: {}'.format(auth)}
+    response.json.return_value = {
+        'status': 'fail',
+        'message': 'Unrecognized workflow ID: {}'.format(auth),
+    }
     response.text = json.dumps(response.json.return_value)
     return response
 

--- a/falcon/test/test_handlers.py
+++ b/falcon/test/test_handlers.py
@@ -32,7 +32,9 @@ class TestWorkflow(object):
 
         `capsys` is a fixture of provided by Pytest, which captures all stdout and stderr streams during the test.
         """
-        test_workflow = queue_handler.Workflow(workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1')
+        test_workflow = queue_handler.Workflow(
+            workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1'
+        )
         print(test_workflow)
 
         captured_stdout, _ = capsys.readouterr()
@@ -46,9 +48,13 @@ class TestWorkflow(object):
         workflow id between 2 Workflow objects, we might also want to check if they have the same bundle_uuid and
         bundle_version.
         """
-        test_workflow1 = queue_handler.Workflow(workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1')
+        test_workflow1 = queue_handler.Workflow(
+            workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1'
+        )
 
-        test_workflow2 = queue_handler.Workflow(workflow_id='fake-workflow-2', bundle_uuid='fake-bundle-uuid-1')
+        test_workflow2 = queue_handler.Workflow(
+            workflow_id='fake-workflow-2', bundle_uuid='fake-bundle-uuid-1'
+        )
 
         assert test_workflow1 != test_workflow2
 
@@ -119,7 +125,11 @@ class TestQueueHandler(object):
         assert isinstance(q, Queue)
         assert q.empty() is True
 
-    @patch.object(queue_handler.QueueHandler, 'execution_loop', new=mock_queue_handler_execution_loop)
+    @patch.object(
+        queue_handler.QueueHandler,
+        'execution_loop',
+        new=mock_queue_handler_execution_loop,
+    )
     def test_queue_handler_can_spawn_and_start_properly(self):
         """
         This function asserts the `queue_handler.spawn_and_start()` can be executed properly.
@@ -162,31 +172,75 @@ class TestQueueHandler(object):
 
         assert 'The thread of this queue handler is not in a running state.' in error
 
-    def test_is_workflow_list_in_oldest_first_order_function_returns_true_on_oldest_first_workflow_list(self):
+    def test_is_workflow_list_in_oldest_first_order_function_returns_true_on_oldest_first_workflow_list(
+        self
+    ):
         """
         This function asserts the static method `is_workflow_list_in_oldest_first_order()` returns `True` if the
         input list of workflows are sorted in oldest-first order on the `submission` field.
         """
         oldest_first_workflow_list = [
-            {'id': 'fake-id-1', 'name': 'fake-name-1', 'status': 'On Hold', 'submission': '2018-01-01T23:49:40.620Z'},
-            {'id': 'fake-id-2', 'name': 'fake-name-2', 'status': 'On Hold', 'submission': '2018-01-02T23:49:40.620Z'},
-            {'id': 'fake-id-3', 'name': 'fake-name-3', 'status': 'On Hold', 'submission': '2018-01-03T23:49:40.620Z'},
+            {
+                'id': 'fake-id-1',
+                'name': 'fake-name-1',
+                'status': 'On Hold',
+                'submission': '2018-01-01T23:49:40.620Z',
+            },
+            {
+                'id': 'fake-id-2',
+                'name': 'fake-name-2',
+                'status': 'On Hold',
+                'submission': '2018-01-02T23:49:40.620Z',
+            },
+            {
+                'id': 'fake-id-3',
+                'name': 'fake-name-3',
+                'status': 'On Hold',
+                'submission': '2018-01-03T23:49:40.620Z',
+            },
         ]
 
-        assert queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(oldest_first_workflow_list) is True
+        assert (
+            queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(
+                oldest_first_workflow_list
+            )
+            is True
+        )
 
-    def test_is_workflow_list_in_oldest_first_order_function_returns_false_on_newest_first_workflow_list(self):
+    def test_is_workflow_list_in_oldest_first_order_function_returns_false_on_newest_first_workflow_list(
+        self
+    ):
         """
         This function asserts the static method `is_workflow_list_in_oldest_first_order()` returns `False` if the
         input list of workflows are sorted in newest-first order on the `submission` field.
         """
         newest_first_workflow_list = [
-            {'id': 'fake-id-1', 'name': 'fake-name-1', 'status': 'On Hold', 'submission': '2018-01-03T23:49:40.620Z'},
-            {'id': 'fake-id-2', 'name': 'fake-name-2', 'status': 'On Hold', 'submission': '2018-01-02T23:49:40.620Z'},
-            {'id': 'fake-id-3', 'name': 'fake-name-3', 'status': 'On Hold', 'submission': '2018-01-01T23:49:40.620Z'},
+            {
+                'id': 'fake-id-1',
+                'name': 'fake-name-1',
+                'status': 'On Hold',
+                'submission': '2018-01-03T23:49:40.620Z',
+            },
+            {
+                'id': 'fake-id-2',
+                'name': 'fake-name-2',
+                'status': 'On Hold',
+                'submission': '2018-01-02T23:49:40.620Z',
+            },
+            {
+                'id': 'fake-id-3',
+                'name': 'fake-name-3',
+                'status': 'On Hold',
+                'submission': '2018-01-01T23:49:40.620Z',
+            },
         ]
 
-        assert queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(newest_first_workflow_list) is False
+        assert (
+            queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(
+                newest_first_workflow_list
+            )
+            is False
+        )
 
     def test_assemble_workflow_can_work_on_workflow_metadata_properly(self):
         """
@@ -231,7 +285,11 @@ class TestQueueHandler(object):
         assert initial_queue_id != final_queue_id
         assert final_queue_id == another_queue_id
 
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_succeed, create=True)
+    @patch(
+        'falcon.queue_handler.CromwellAPI.query',
+        cromwell_simulator.query_workflows_succeed,
+        create=True,
+    )
     def test_retrieve_workflows_returns_query_results_successfully(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly when it gets 200 OK from
@@ -248,7 +306,11 @@ class TestQueueHandler(object):
         assert num_workflows > 0
         assert 'Retrieved {0} workflows from Cromwell.'.format(num_workflows) in info
 
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500, create=True)
+    @patch(
+        'falcon.queue_handler.CromwellAPI.query',
+        cromwell_simulator.query_workflows_fail_with_500,
+        create=True,
+    )
     def test_retrieve_workflows_returns_none_for_500_response_code(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly when it gets 500 error code from
@@ -263,7 +325,11 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in warn
 
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_400, create=True)
+    @patch(
+        'falcon.queue_handler.CromwellAPI.query',
+        cromwell_simulator.query_workflows_fail_with_400,
+        create=True,
+    )
     def test_retrieve_workflows_returns_none_for_400_response_code(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly when it gets 400 error code from
@@ -279,7 +345,9 @@ class TestQueueHandler(object):
         assert 'Failed to retrieve workflows from Cromwell' in warn
 
     @patch(
-        'falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_raises_ConnectionError, create=True
+        'falcon.queue_handler.CromwellAPI.query',
+        cromwell_simulator.query_workflows_raises_ConnectionError,
+        create=True,
     )
     def test_retrieve_workflows_returns_none_for_connection_error(self, caplog):
         """
@@ -323,7 +391,9 @@ class TestQueueHandler(object):
         assert test_handler.workflow_queue.empty() is True
 
         mock_workflow = queue_handler.Workflow(
-            workflow_id='fake_workflow_id', bundle_uuid='fake_bundle_uuid', bundle_version='fake_bundle_version'
+            workflow_id='fake_workflow_id',
+            bundle_uuid='fake_bundle_uuid',
+            bundle_version='fake_bundle_version',
         )
         test_handler.enqueue(iter([mock_workflow]))
         assert test_handler.workflow_queue.empty() is False
@@ -346,8 +416,14 @@ class TestQueueHandler(object):
             assert item.id == expect_result[idx]
 
     @pytest.mark.timeout(2)
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500, create=True)
-    def test_execution_event_goes_back_to_sleep_directly_when_it_fails_to_retrieve_workflows(self, caplog):
+    @patch(
+        'falcon.queue_handler.CromwellAPI.query',
+        cromwell_simulator.query_workflows_fail_with_500,
+        create=True,
+    )
+    def test_execution_event_goes_back_to_sleep_directly_when_it_fails_to_retrieve_workflows(
+        self, caplog
+    ):
         """
         This function asserts when the `queue_handler.execution_event()` fails to retrieve any workflow, it will go
         back to sleep directly.
@@ -364,5 +440,12 @@ class TestQueueHandler(object):
         info = caplog.text
 
         assert 'is warmed up and running.' in info
-        assert 'Cannot fetch any workflow from Cromwell, go back to sleep and wait for next attempt.' in info
-        assert test_handler.queue_update_interval <= elapsed <= test_handler.queue_update_interval * 1.5
+        assert (
+            'Cannot fetch any workflow from Cromwell, go back to sleep and wait for next attempt.'
+            in info
+        )
+        assert (
+            test_handler.queue_update_interval
+            <= elapsed
+            <= test_handler.queue_update_interval * 1.5
+        )

--- a/falcon/test/test_handlers.py
+++ b/falcon/test/test_handlers.py
@@ -32,8 +32,7 @@ class TestWorkflow(object):
 
         `capsys` is a fixture of provided by Pytest, which captures all stdout and stderr streams during the test.
         """
-        test_workflow = queue_handler.Workflow(
-                workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1')
+        test_workflow = queue_handler.Workflow(workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1')
         print(test_workflow)
 
         captured_stdout, _ = capsys.readouterr()
@@ -47,11 +46,9 @@ class TestWorkflow(object):
         workflow id between 2 Workflow objects, we might also want to check if they have the same bundle_uuid and
         bundle_version.
         """
-        test_workflow1 = queue_handler.Workflow(
-                workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1')
+        test_workflow1 = queue_handler.Workflow(workflow_id='fake-workflow-1', bundle_uuid='fake-bundle-uuid-1')
 
-        test_workflow2 = queue_handler.Workflow(
-                workflow_id='fake-workflow-2', bundle_uuid='fake-bundle-uuid-1')
+        test_workflow2 = queue_handler.Workflow(workflow_id='fake-workflow-2', bundle_uuid='fake-bundle-uuid-1')
 
         assert test_workflow1 != test_workflow2
 
@@ -76,41 +73,41 @@ class TestQueueHandler(object):
     config_path = '{0}{1}'.format(data_dir, cromwell_config)
     mock_workflow_metas = [
         {
-            'id'        : 'fake-id-1',
-            'name'      : 'fake-name-1',
-            'status'    : 'On Hold',
+            'id': 'fake-id-1',
+            'name': 'fake-name-1',
+            'status': 'On Hold',
             'submission': '2018-01-01T23:49:40.620Z',
-            'labels'    : {
+            'labels': {
                 'cromwell-workflow-id': 'cromwell-fake-id-1',
-                'bundle-uuid'         : 'fake-bundle-uuid-1',
-                'bundle-version'      : '2018-01-01T22:49:40.620Z',
-                'workflow-name'       : 'fake-name-1'
-            }
+                'bundle-uuid': 'fake-bundle-uuid-1',
+                'bundle-version': '2018-01-01T22:49:40.620Z',
+                'workflow-name': 'fake-name-1',
+            },
         },
         {
-            'id'        : 'fake-id-2',
-            'name'      : 'fake-name-2',
-            'status'    : 'On Hold',
+            'id': 'fake-id-2',
+            'name': 'fake-name-2',
+            'status': 'On Hold',
             'submission': '2018-01-02T23:49:40.620Z',
-            'labels'    : {
+            'labels': {
                 'cromwell-workflow-id': 'cromwell-fake-id-2',
-                'bundle-uuid'         : 'fake-bundle-uuid-2',
-                'bundle-version'      : '2018-01-01T22:49:40.620Z',
-                'workflow-name'       : 'fake-name-2'
-            }
+                'bundle-uuid': 'fake-bundle-uuid-2',
+                'bundle-version': '2018-01-01T22:49:40.620Z',
+                'workflow-name': 'fake-name-2',
+            },
         },
         {
-            'id'        : 'fake-id-3',
-            'name'      : 'fake-name-3',
-            'status'    : 'On Hold',
+            'id': 'fake-id-3',
+            'name': 'fake-name-3',
+            'status': 'On Hold',
             'submission': '2018-01-03T23:49:40.620Z',
-            'labels'    : {
+            'labels': {
                 'cromwell-workflow-id': 'cromwell-fake-id-3',
-                'bundle-uuid'         : 'fake-bundle-uuid-3',
-                'bundle-version'      : '2018-01-01T22:49:40.620Z',
-                'workflow-name'       : 'fake-name-3'
-            }
-        }
+                'bundle-uuid': 'fake-bundle-uuid-3',
+                'bundle-version': '2018-01-01T22:49:40.620Z',
+                'workflow-name': 'fake-name-3',
+            },
+        },
     ]
 
     def test_create_empty_queue_returns_a_valid_empty_queue_object(self):
@@ -171,29 +168,12 @@ class TestQueueHandler(object):
         input list of workflows are sorted in oldest-first order on the `submission` field.
         """
         oldest_first_workflow_list = [
-            {
-                'id'        : 'fake-id-1',
-                'name'      : 'fake-name-1',
-                'status'    : 'On Hold',
-                'submission': '2018-01-01T23:49:40.620Z'
-            },
-            {
-                'id'        : 'fake-id-2',
-                'name'      : 'fake-name-2',
-                'status'    : 'On Hold',
-                'submission': '2018-01-02T23:49:40.620Z'
-            },
-            {
-                'id'        : 'fake-id-3',
-                'name'      : 'fake-name-3',
-                'status'    : 'On Hold',
-                'submission': '2018-01-03T23:49:40.620Z'
-            }
+            {'id': 'fake-id-1', 'name': 'fake-name-1', 'status': 'On Hold', 'submission': '2018-01-01T23:49:40.620Z'},
+            {'id': 'fake-id-2', 'name': 'fake-name-2', 'status': 'On Hold', 'submission': '2018-01-02T23:49:40.620Z'},
+            {'id': 'fake-id-3', 'name': 'fake-name-3', 'status': 'On Hold', 'submission': '2018-01-03T23:49:40.620Z'},
         ]
 
-        assert queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(
-                oldest_first_workflow_list
-        ) is True
+        assert queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(oldest_first_workflow_list) is True
 
     def test_is_workflow_list_in_oldest_first_order_function_returns_false_on_newest_first_workflow_list(self):
         """
@@ -201,29 +181,12 @@ class TestQueueHandler(object):
         input list of workflows are sorted in newest-first order on the `submission` field.
         """
         newest_first_workflow_list = [
-            {
-                'id'        : 'fake-id-1',
-                'name'      : 'fake-name-1',
-                'status'    : 'On Hold',
-                'submission': '2018-01-03T23:49:40.620Z'
-            },
-            {
-                'id'        : 'fake-id-2',
-                'name'      : 'fake-name-2',
-                'status'    : 'On Hold',
-                'submission': '2018-01-02T23:49:40.620Z'
-            },
-            {
-                'id'        : 'fake-id-3',
-                'name'      : 'fake-name-3',
-                'status'    : 'On Hold',
-                'submission': '2018-01-01T23:49:40.620Z'
-            }
+            {'id': 'fake-id-1', 'name': 'fake-name-1', 'status': 'On Hold', 'submission': '2018-01-03T23:49:40.620Z'},
+            {'id': 'fake-id-2', 'name': 'fake-name-2', 'status': 'On Hold', 'submission': '2018-01-02T23:49:40.620Z'},
+            {'id': 'fake-id-3', 'name': 'fake-name-3', 'status': 'On Hold', 'submission': '2018-01-01T23:49:40.620Z'},
         ]
 
-        assert queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(
-                newest_first_workflow_list
-        ) is False
+        assert queue_handler.QueueHandler.is_workflow_list_in_oldest_first_order(newest_first_workflow_list) is False
 
     def test_assemble_workflow_can_work_on_workflow_metadata_properly(self):
         """
@@ -231,16 +194,16 @@ class TestQueueHandler(object):
         and assemble it as a `Workflow` instance.
         """
         test_metadata = {
-            'id'        : 'fake-id-1',
-            'name'      : 'fake-name-1',
-            'status'    : 'On Hold',
+            'id': 'fake-id-1',
+            'name': 'fake-name-1',
+            'status': 'On Hold',
             'submission': '2018-01-01T23:49:40.620Z',
-            'labels'    : {
+            'labels': {
                 'cromwell-workflow-id': 'cromwell-fake-id-1',
-                'bundle-uuid'         : 'fake-bundle-uuid-1',
-                'bundle-version'      : '2018-01-01T22:49:40.620Z',
-                'workflow-name'       : 'fake-name-1'
-            }
+                'bundle-uuid': 'fake-bundle-uuid-1',
+                'bundle-version': '2018-01-01T22:49:40.620Z',
+                'workflow-name': 'fake-name-1',
+            },
         }
         test_handler = queue_handler.QueueHandler(self.config_path)
         workflow = test_handler._assemble_workflow(test_metadata)
@@ -268,8 +231,7 @@ class TestQueueHandler(object):
         assert initial_queue_id != final_queue_id
         assert final_queue_id == another_queue_id
 
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_succeed,
-           create=True)
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_succeed, create=True)
     def test_retrieve_workflows_returns_query_results_successfully(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly when it gets 200 OK from
@@ -286,8 +248,7 @@ class TestQueueHandler(object):
         assert num_workflows > 0
         assert 'Retrieved {0} workflows from Cromwell.'.format(num_workflows) in info
 
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500,
-           create=True)
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500, create=True)
     def test_retrieve_workflows_returns_none_for_500_response_code(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly when it gets 500 error code from
@@ -302,8 +263,7 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in warn
 
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_400,
-           create=True)
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_400, create=True)
     def test_retrieve_workflows_returns_none_for_400_response_code(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly when it gets 400 error code from
@@ -318,9 +278,9 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in warn
 
-    @patch('falcon.queue_handler.CromwellAPI.query',
-           cromwell_simulator.query_workflows_raises_ConnectionError,
-           create=True)
+    @patch(
+        'falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_raises_ConnectionError, create=True
+    )
     def test_retrieve_workflows_returns_none_for_connection_error(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly if it runs into connection
@@ -335,9 +295,11 @@ class TestQueueHandler(object):
         assert results is None
         assert 'Failed to retrieve workflows from Cromwell' in error
 
-    @patch('falcon.queue_handler.CromwellAPI.query',
-           cromwell_simulator.query_workflows_raises_RequestException,
-           create=True)
+    @patch(
+        'falcon.queue_handler.CromwellAPI.query',
+        cromwell_simulator.query_workflows_raises_RequestException,
+        create=True,
+    )
     def test_retrieve_workflows_returns_none_for_400_requests_exception(self, caplog):
         """
         This function asserts the `queue_handler.retrieve_workflows()` works properly if it runs into requests
@@ -361,9 +323,8 @@ class TestQueueHandler(object):
         assert test_handler.workflow_queue.empty() is True
 
         mock_workflow = queue_handler.Workflow(
-                workflow_id='fake_workflow_id',
-                bundle_uuid='fake_bundle_uuid',
-                bundle_version='fake_bundle_version')
+            workflow_id='fake_workflow_id', bundle_uuid='fake_bundle_uuid', bundle_version='fake_bundle_version'
+        )
         test_handler.enqueue(iter([mock_workflow]))
         assert test_handler.workflow_queue.empty() is False
 
@@ -385,8 +346,7 @@ class TestQueueHandler(object):
             assert item.id == expect_result[idx]
 
     @pytest.mark.timeout(2)
-    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500,
-           create=True)
+    @patch('falcon.queue_handler.CromwellAPI.query', cromwell_simulator.query_workflows_fail_with_500, create=True)
     def test_execution_event_goes_back_to_sleep_directly_when_it_fails_to_retrieve_workflows(self, caplog):
         """
         This function asserts when the `queue_handler.execution_event()` fails to retrieve any workflow, it will go

--- a/falcon/test/test_igniters.py
+++ b/falcon/test/test_igniters.py
@@ -35,21 +35,20 @@ class TestIgniter(object):
     `@patch`s in the class monkey patches the functions that need to talk to an external resource, so that
     we can test the igniter without actually talking to the external resource, in this case, the Cromwell API.
     """
+
     data_dir = '{}/data/'.format(os.path.split(__file__)[0])
     cromwell_config = 'example_config_cromwell_instance.json'
     config_path = '{0}{1}'.format(data_dir, cromwell_config)
     mock_workflow = queue_handler.Workflow(
-            workflow_id='fake_workflow_id',
-            bundle_uuid='fake_bundle_uuid',
-            bundle_version='fake_bundle_version')
+        workflow_id='fake_workflow_id', bundle_uuid='fake_bundle_uuid', bundle_version='fake_bundle_version'
+    )
 
     def test_igniter_cannot_spawn_and_start_without_having_a_reference_to_a_queue_handler_object(self):
         """
         This function asserts the `igniter.spawn_and_start()` can only run by accepting a valid
         `queue_handler.QueueHandler` object, otherwise it will throws a `TypeError`.
         """
-        not_a_real_queue_handler = type('fake_handler', (object,), {
-            'method': lambda self: print('')})()
+        not_a_real_queue_handler = type('fake_handler', (object,), {'method': lambda self: print('')})()
 
         with pytest.raises(TypeError):
             test_igniter = igniter.Igniter(self.config_path)
@@ -66,8 +65,7 @@ class TestIgniter(object):
 
         try:
             test_igniter.spawn_and_start(mock_handler)
-            mock_igniter_execution_loop.assert_called_once_with(
-                    test_igniter, mock_handler)
+            mock_igniter_execution_loop.assert_called_once_with(test_igniter, mock_handler)
         finally:
             test_igniter.thread.join()
 
@@ -161,8 +159,11 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in warn
 
-    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_raises_ConnectionError,
-           create=True)
+    @patch(
+        'falcon.igniter.CromwellAPI.release_hold',
+        cromwell_simulator.release_workflow_raises_ConnectionError,
+        create=True,
+    )
     def test_release_workflow_handles_connection_error(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it runs into connection errors
@@ -177,8 +178,11 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in error
 
-    @patch('falcon.igniter.CromwellAPI.release_hold',
-           cromwell_simulator.release_workflow_raises_RequestException, create=True)
+    @patch(
+        'falcon.igniter.CromwellAPI.release_hold',
+        cromwell_simulator.release_workflow_raises_RequestException,
+        create=True,
+    )
     def test_release_workflow_handles_requests_exception(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it runs into requests exceptions

--- a/falcon/test/test_igniters.py
+++ b/falcon/test/test_igniters.py
@@ -40,15 +40,21 @@ class TestIgniter(object):
     cromwell_config = 'example_config_cromwell_instance.json'
     config_path = '{0}{1}'.format(data_dir, cromwell_config)
     mock_workflow = queue_handler.Workflow(
-        workflow_id='fake_workflow_id', bundle_uuid='fake_bundle_uuid', bundle_version='fake_bundle_version'
+        workflow_id='fake_workflow_id',
+        bundle_uuid='fake_bundle_uuid',
+        bundle_version='fake_bundle_version',
     )
 
-    def test_igniter_cannot_spawn_and_start_without_having_a_reference_to_a_queue_handler_object(self):
+    def test_igniter_cannot_spawn_and_start_without_having_a_reference_to_a_queue_handler_object(
+        self
+    ):
         """
         This function asserts the `igniter.spawn_and_start()` can only run by accepting a valid
         `queue_handler.QueueHandler` object, otherwise it will throws a `TypeError`.
         """
-        not_a_real_queue_handler = type('fake_handler', (object,), {'method': lambda self: print('')})()
+        not_a_real_queue_handler = type(
+            'fake_handler', (object,), {'method': lambda self: print('')}
+        )()
 
         with pytest.raises(TypeError):
             test_igniter = igniter.Igniter(self.config_path)
@@ -65,7 +71,9 @@ class TestIgniter(object):
 
         try:
             test_igniter.spawn_and_start(mock_handler)
-            mock_igniter_execution_loop.assert_called_once_with(test_igniter, mock_handler)
+            mock_igniter_execution_loop.assert_called_once_with(
+                test_igniter, mock_handler
+            )
         finally:
             test_igniter.thread.join()
 
@@ -100,7 +108,11 @@ class TestIgniter(object):
 
         assert 'The thread of this igniter is not in a running state.' in error
 
-    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_succeed, create=True)
+    @patch(
+        'falcon.igniter.CromwellAPI.release_hold',
+        cromwell_simulator.release_workflow_succeed,
+        create=True,
+    )
     def test_release_workflow_successfully_releases_a_workflow(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 200 OK from the Cromwell.
@@ -114,7 +126,11 @@ class TestIgniter(object):
 
         assert 'Released a workflow fake_workflow_id' in info
 
-    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_with_403, create=True)
+    @patch(
+        'falcon.igniter.CromwellAPI.release_hold',
+        cromwell_simulator.release_workflow_with_403,
+        create=True,
+    )
     def test_release_workflow_handles_403_response_code(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 403 error from the
@@ -129,7 +145,11 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in warn
 
-    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_with_404, create=True)
+    @patch(
+        'falcon.igniter.CromwellAPI.release_hold',
+        cromwell_simulator.release_workflow_with_404,
+        create=True,
+    )
     def test_release_workflow_handles_404_response_code(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 404 error from the
@@ -144,7 +164,11 @@ class TestIgniter(object):
 
         assert 'Failed to release a workflow fake_workflow_id' in warn
 
-    @patch('falcon.igniter.CromwellAPI.release_hold', cromwell_simulator.release_workflow_with_500, create=True)
+    @patch(
+        'falcon.igniter.CromwellAPI.release_hold',
+        cromwell_simulator.release_workflow_with_500,
+        create=True,
+    )
     def test_release_workflow_handles_500_response_code(self, caplog):
         """
         This function asserts the `igniter.release_workflow()` can work properly when it gets 500 error from the
@@ -218,5 +242,12 @@ class TestIgniter(object):
 
         info = caplog.text
 
-        assert 'The in-memory queue is empty, go back to sleep and wait for the handler to retrieve workflows.' in info
-        assert test_igniter.workflow_start_interval <= elapsed <= test_igniter.workflow_start_interval * 1.5
+        assert (
+            'The in-memory queue is empty, go back to sleep and wait for the handler to retrieve workflows.'
+            in info
+        )
+        assert (
+            test_igniter.workflow_start_interval
+            <= elapsed
+            <= test_igniter.workflow_start_interval * 1.5
+        )

--- a/falcon/test/test_settings.py
+++ b/falcon/test/test_settings.py
@@ -25,11 +25,14 @@ class TestSettings(object):
         assert loaded_settings['use_caas'] == self.expected_settings_dic_cromwell_instance.get('use_caas')
         assert loaded_settings['cromwell_user'] == self.expected_settings_dic_cromwell_instance.get('cromwell_user')
         assert loaded_settings['cromwell_password'] == self.expected_settings_dic_cromwell_instance.get(
-                'cromwell_password')
-        assert loaded_settings['queue_update_interval'] == int(self.expected_settings_dic_cromwell_instance.get(
-                'queue_update_interval'))
-        assert loaded_settings['workflow_start_interval'] == int(self.expected_settings_dic_cromwell_instance.get(
-                'workflow_start_interval'))
+            'cromwell_password'
+        )
+        assert loaded_settings['queue_update_interval'] == int(
+            self.expected_settings_dic_cromwell_instance.get('queue_update_interval')
+        )
+        assert loaded_settings['workflow_start_interval'] == int(
+            self.expected_settings_dic_cromwell_instance.get('workflow_start_interval')
+        )
 
     def test_get_settings_cromwell_query_dict_includes_on_hold_status(self):
         loaded_settings = settings.get_settings('{0}{1}'.format(self.data_dir, self.cromwell_config))
@@ -55,7 +58,9 @@ class TestSettings(object):
             assert loaded_settings['use_caas'] == self.expected_settings_dic_caas.get('use_caas')
             assert loaded_settings['caas_key'] == 'encrypted_key_content_string_to_communicate_with_caas'
             assert loaded_settings['collection_name'] == self.expected_settings_dic_caas.get('collection_name')
-            assert loaded_settings['queue_update_interval'] == int(self.expected_settings_dic_caas.get(
-                    'queue_update_interval'))
-            assert loaded_settings['workflow_start_interval'] == int(self.expected_settings_dic_caas.get(
-                    'workflow_start_interval'))
+            assert loaded_settings['queue_update_interval'] == int(
+                self.expected_settings_dic_caas.get('queue_update_interval')
+            )
+            assert loaded_settings['workflow_start_interval'] == int(
+                self.expected_settings_dic_caas.get('workflow_start_interval')
+            )

--- a/falcon/test/test_settings.py
+++ b/falcon/test/test_settings.py
@@ -16,17 +16,27 @@ class TestSettings(object):
     with open('{0}{1}'.format(data_dir, caas_config)) as f:
         expected_settings_dic_caas = json.load(f)
 
-    def test_get_settings_loads_config_file_for_cromwell_instance_without_exceptions(self):
+    def test_get_settings_loads_config_file_for_cromwell_instance_without_exceptions(
+        self
+    ):
         settings.get_settings('{0}{1}'.format(self.data_dir, self.cromwell_config))
 
     def test_get_settings_loads_config_file_for_cromwell_instance_correctly(self):
-        loaded_settings = settings.get_settings('{0}{1}'.format(self.data_dir, self.cromwell_config))
-        assert loaded_settings['cromwell_url'] == self.expected_settings_dic_cromwell_instance.get('cromwell_url')
-        assert loaded_settings['use_caas'] == self.expected_settings_dic_cromwell_instance.get('use_caas')
-        assert loaded_settings['cromwell_user'] == self.expected_settings_dic_cromwell_instance.get('cromwell_user')
-        assert loaded_settings['cromwell_password'] == self.expected_settings_dic_cromwell_instance.get(
-            'cromwell_password'
+        loaded_settings = settings.get_settings(
+            '{0}{1}'.format(self.data_dir, self.cromwell_config)
         )
+        assert loaded_settings[
+            'cromwell_url'
+        ] == self.expected_settings_dic_cromwell_instance.get('cromwell_url')
+        assert loaded_settings[
+            'use_caas'
+        ] == self.expected_settings_dic_cromwell_instance.get('use_caas')
+        assert loaded_settings[
+            'cromwell_user'
+        ] == self.expected_settings_dic_cromwell_instance.get('cromwell_user')
+        assert loaded_settings[
+            'cromwell_password'
+        ] == self.expected_settings_dic_cromwell_instance.get('cromwell_password')
         assert loaded_settings['queue_update_interval'] == int(
             self.expected_settings_dic_cromwell_instance.get('queue_update_interval')
         )
@@ -35,29 +45,55 @@ class TestSettings(object):
         )
 
     def test_get_settings_cromwell_query_dict_includes_on_hold_status(self):
-        loaded_settings = settings.get_settings('{0}{1}'.format(self.data_dir, self.cromwell_config))
+        loaded_settings = settings.get_settings(
+            '{0}{1}'.format(self.data_dir, self.cromwell_config)
+        )
         assert loaded_settings['cromwell_query_dict']['status'] == 'On Hold'
 
-    def test_get_settings_loads_config_file_for_caas_throw_exceptions_without_caas_key(self):
+    def test_get_settings_loads_config_file_for_caas_throw_exceptions_without_caas_key(
+        self
+    ):
         with pytest.raises(ValueError):
             settings.get_settings('{0}{1}'.format(self.data_dir, self.caas_config))
 
-    def test_get_settings_loads_config_file_for_caas_for_capital_env_variable_correctly(self, monkeypatch):
+    def test_get_settings_loads_config_file_for_caas_for_capital_env_variable_correctly(
+        self, monkeypatch
+    ):
         with monkeypatch.context() as ctx:
-            ctx.setenv('CAAS_KEY', 'encrypted_key_content_string_to_communicate_with_caas')
+            ctx.setenv(
+                'CAAS_KEY', 'encrypted_key_content_string_to_communicate_with_caas'
+            )
 
-            loaded_settings = settings.get_settings('{0}{1}'.format(self.data_dir, self.caas_config))
-            assert loaded_settings['caas_key'] == 'encrypted_key_content_string_to_communicate_with_caas'
+            loaded_settings = settings.get_settings(
+                '{0}{1}'.format(self.data_dir, self.caas_config)
+            )
+            assert (
+                loaded_settings['caas_key']
+                == 'encrypted_key_content_string_to_communicate_with_caas'
+            )
 
     def test_get_settings_loads_config_file_for_caas_correctly(self, monkeypatch):
         with monkeypatch.context() as ctx:
-            ctx.setenv('caas_key', 'encrypted_key_content_string_to_communicate_with_caas')
+            ctx.setenv(
+                'caas_key', 'encrypted_key_content_string_to_communicate_with_caas'
+            )
 
-            loaded_settings = settings.get_settings('{0}{1}'.format(self.data_dir, self.caas_config))
-            assert loaded_settings['cromwell_url'] == self.expected_settings_dic_caas.get('cromwell_url')
-            assert loaded_settings['use_caas'] == self.expected_settings_dic_caas.get('use_caas')
-            assert loaded_settings['caas_key'] == 'encrypted_key_content_string_to_communicate_with_caas'
-            assert loaded_settings['collection_name'] == self.expected_settings_dic_caas.get('collection_name')
+            loaded_settings = settings.get_settings(
+                '{0}{1}'.format(self.data_dir, self.caas_config)
+            )
+            assert loaded_settings[
+                'cromwell_url'
+            ] == self.expected_settings_dic_caas.get('cromwell_url')
+            assert loaded_settings['use_caas'] == self.expected_settings_dic_caas.get(
+                'use_caas'
+            )
+            assert (
+                loaded_settings['caas_key']
+                == 'encrypted_key_content_string_to_communicate_with_caas'
+            )
+            assert loaded_settings[
+                'collection_name'
+            ] == self.expected_settings_dic_caas.get('collection_name')
             assert loaded_settings['queue_update_interval'] == int(
                 self.expected_settings_dic_caas.get('queue_update_interval')
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-git+git://github.com/broadinstitute/cromwell-tools.git@v1.1.1
+black==19.3b0
+cromwell-tools==1.1.1
+flake8==3.7.7
+pre-commit==1.14.4
 pytest==3.6.3
 pytest-timeout==1.3.1
 pytest-cov==2.5.1


### PR DESCRIPTION
Initial efforts on https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530

## Changes:
- [x] Add [Black](https://black.readthedocs.io/en/stable/index.html) as the code formatter for Falcon.
- [x] Use Black to format and lint the Falcon code base with `black falcon --skip-string-normalization`
- [x] Add Flake-8 and its configuration to the repo.
- [x] Update the Travis CI config so we have a linting test before all of the other tests.
- [x] Add `pre-commit` and update the requirements as well as the readme.
- [x] Add some status badges.
 

## Review+QA Instructions:

- Please check if there are any deal-breakers that Black provides here, for instance:
    - Do you think it's OK to always add `()` everywhere? Black adds them almost everywhere.
    - Do you think it's OK to have extra lines?
    - Do you think it's OK to always dedent the closing brackets and add a trailing comma? Black does that to produce smaller diffs in code reviews.
    - etc.
- Please check the new multi-stage test on Travis: https://travis-ci.com/HumanCellAtlas/falcon/builds/105025308
- Please follow the updated readme, make sure the `pre-commit` is installed on your local environment and if feasible, try to make a commit (e.g. add an empty line to the readme, but don't push it), see if the hook works.