### PR TITLE
Yanc noop on mdata update

### DIFF
--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -58,10 +58,9 @@ class Igniter(object):
         )
         try:
             workflow = handler.workflow_queue.get(block=False)
-            force = (
-                isinstance(workflow.labels, dict) and 'force' in workflow.labels.keys()
-            )
-            if not force and self.workflow_is_duplicate(workflow):
+            if 'force' not in workflow.labels.keys() and self.workflow_is_duplicate(
+                workflow
+            ):
                 logger.info(
                     'Igniter | Found existing workflow with the same hash-id; '
                     f'aborting workflow {workflow} | {datetime.now()}'

--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -58,13 +58,15 @@ class Igniter(object):
         )
         try:
             workflow = handler.workflow_queue.get(block=False)
-            if 'force' not in workflow.labels.keys() and self.workflow_is_duplicate(
-                workflow
-            ):
+            force = (
+                isinstance(workflow.labels, dict) and 'force' in workflow.labels.keys()
+            )
+            if not force and self.workflow_is_duplicate(workflow):
                 logger.info(
-                    'Igniter | Found existing workflow with the same key-data-hash; '
-                    f'skipping workflow {workflow} | {datetime.now()}'
+                    'Igniter | Found existing workflow with the same hash-id; '
+                    f'aborting workflow {workflow} | {datetime.now()}'
                 )
+                self.abort_workflow(workflow)
             else:
                 self.release_workflow(workflow)
         except queue.Empty:
@@ -72,56 +74,6 @@ class Igniter(object):
                 'Igniter | The in-memory queue is empty, go back to sleep and wait for the handler to retrieve '
                 f'workflows. | {datetime.now()}'
             )
-        finally:
-            self.sleep_for(self.workflow_start_interval)
-
-    def release_workflow(self, workflow):
-        try:
-            response = CromwellAPI.release_hold(
-                uuid=workflow.id, auth=self.cromwell_auth
-            )
-            if response.status_code != 200:
-                logger.warning(
-                    f'Igniter | Failed to release a workflow {workflow} | {response.text} | {datetime.now()}'
-                )
-            else:
-                logger.info(
-                    f'Igniter | Released a workflow {workflow} | {datetime.now()}'
-                )
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.RequestException,
-        ) as error:
-            logger.error(
-                f'Igniter | Failed to release a workflow {workflow} | {error} | {datetime.now()}'
-            )
-
-    def abort_workflow(self, workflow):
-        try:
-            response = CromwellAPI.abort(uuid=workflow.id, auth=self.cromwell_auth)
-            if response.status_code != 200:
-                logger.warning(
-                    f'Igniter | Failed to abort a workflow {workflow} | {response.text} | {datetime.now()}'
-                )
-            else:
-                logger.info(
-                    f'Igniter | Aborted a workflow {workflow} | {datetime.now()}'
-                )
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.RequestException,
-        ) as error:
-            logger.error(
-                f'Igniter | Failed to abort a workflow {workflow} | {error} | {datetime.now()}'
-            )
-
-    def workflow_is_duplicate(self, workflow):
-        data_hash = workflow.labels.get('key-data-hash')
-        query_dict = {'label': f'key-data-hash:{data_hash}'}
-        try:
-            response = CromwellAPI.query(query_dict, self.cromwell_auth)
-            results = response.json()['results']
-            return any([result['id'] != workflow.id for result in results])
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.RequestException,
@@ -129,6 +81,54 @@ class Igniter(object):
             logger.error(
                 f'Igniter | Failed to query cromwell for existing workflows {error} | {datetime.now()}'
             )
+        finally:
+            self.sleep_for(self.workflow_start_interval)
+
+    def simple_cromwell_workflow_action(
+        self, do_thing, workflow, failure_message, success_message
+    ):
+        try:
+            response = do_thing(uuid=workflow.id, auth=self.cromwell_auth)
+            if response.status_code != 200:
+                logger.warning(
+                    f'Igniter | {failure_message} {workflow} | {response.text} | {datetime.now()}'
+                )
+            else:
+                logger.info(
+                    f'Igniter | {success_message} {workflow} | {datetime.now()}'
+                )
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
+        ) as error:
+            logger.error(
+                f'Igniter | {failure_message} {workflow} | {error} | {datetime.now()}'
+            )
+
+    def release_workflow(self, workflow):
+        self.simple_cromwell_workflow_action(
+            do_thing=CromwellAPI.release_hold,
+            workflow=workflow,
+            failure_message='Failed to release a workflow',
+            success_message='Released a workflow',
+        )
+
+    def abort_workflow(self, workflow):
+        self.simple_cromwell_workflow_action(
+            do_thing=CromwellAPI.abort,
+            workflow=workflow,
+            failure_message='Failed to abort a workflow',
+            success_message='Aborted a workflow',
+        )
+
+    def workflow_is_duplicate(self, workflow):
+        hash_id = workflow.labels.get('hash-id')
+        query_dict = {'label': f'hash-id:{hash_id}'}
+        response = CromwellAPI.query(
+            query_dict, self.cromwell_auth, raise_for_status=True
+        )
+        results = response.json()['results']
+        return any([result['id'] != workflow.id for result in results])
 
     @staticmethod
     def sleep_for(sleep_time):

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -19,10 +19,11 @@ class Workflow(object):
     Besides the features for de-duplication, this class also utilizes a smaller size of chunk in memory.
     """
 
-    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None):
+    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None, labels=None):
         self.id = workflow_id
         self.bundle_uuid = bundle_uuid
         self.bundle_version = bundle_version
+        self.labels = labels
 
     def __str__(self):
         return str(self.id)
@@ -287,9 +288,7 @@ class QueueHandler(object):
             Workflow: A concrete `Workflow` instance that has necessary properties.
         """
         workflow_id = workflow_meta.get('id')
-        workflow_labels = workflow_meta.get(
-            'labels'
-        )  # TODO: Integrate this field into Workflow class
+        workflow_labels = workflow_meta.get('labels')
         workflow_bundle_uuid = (
             workflow_labels.get('bundle-uuid')
             if isinstance(workflow_labels, dict)
@@ -300,7 +299,9 @@ class QueueHandler(object):
             if isinstance(workflow_labels, dict)
             else None
         )
-        workflow = Workflow(workflow_id, workflow_bundle_uuid, workflow_bundle_version)
+        workflow = Workflow(
+            workflow_id, workflow_bundle_uuid, workflow_bundle_version, workflow_labels
+        )
         return workflow
 
     @staticmethod

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 from queue import Queue
 from threading import Thread, get_ident
+from copy import deepcopy
 
 import requests
 from cromwell_tools.cromwell_api import CromwellAPI
@@ -19,11 +20,15 @@ class Workflow(object):
     Besides the features for de-duplication, this class also utilizes a smaller size of chunk in memory.
     """
 
-    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None, labels={}):
+    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None, labels=None):
+
         self.id = workflow_id
         self.bundle_uuid = bundle_uuid
         self.bundle_version = bundle_version
-        self.labels = labels
+        if labels is None:
+            self.labels = {}
+        else:
+            self.labels = deepcopy(labels)
 
     def __str__(self):
         return str(self.id)

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -19,7 +19,7 @@ class Workflow(object):
     Besides the features for de-duplication, this class also utilizes a smaller size of chunk in memory.
     """
 
-    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None, labels=None):
+    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None, labels={}):
         self.id = workflow_id
         self.bundle_uuid = bundle_uuid
         self.bundle_version = bundle_version

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -23,13 +23,24 @@ def release_workflow_raises_RequestException(uuid, auth):
     raise requests.exceptions.RequestException
 
 
-def query_workflows_succeed(query_dict, auth):
+def query_workflows_succeed(query_dict, auth, raise_for_status=False):
     response = Mock(spec=Response)
     response.status_code = 200
     response.json.return_value = {
         'results': [
             {'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'}
             for i in range(random.randint(1, 10))
+        ]
+    }
+    return response
+
+
+def query_workflows_return_fake_workflow(query_dict, auth, raise_for_status=False):
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.json.return_value = {
+        'results': [
+            {'id': 'fake_workflow_id', 'submission': '2018-05-25T19:03:51.736Z'}
         ]
     }
     return response


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

prevent reanalysis of functionally equivalent data - i.e. noop when metadata updates that would not affect analysis results trigger a subscription notification
[JIRA
](https://broadinstitute.atlassian.net/browse/GH-198)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

-now queries Cromwell for workflows containing the same hash-id label before releasing on-hold workflows.
-aborts workflows when it finds other workflows with the same hash-id
-unit tests

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
