### PR TITLE
Enable noop by requesting workflow labels when querying cromwell

### DIFF
--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -156,6 +156,7 @@ class QueueHandler(object):
             ```
         """
         workflow_metas = None
+        query_dict['additionalQueryResultFields'] = 'labels'
         try:
             response = CromwellAPI.query(auth=self.cromwell_auth, query_dict=query_dict)
             if response.status_code != 200:


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

Noop wasn't working because Falcon didn't request workflow labels when querying on-hold workflows from cromwell.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

falcon now requests workflow labels

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
