### PR TITLE
Update de-duplication logic

### DIFF
--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -136,7 +136,8 @@ class Igniter(object):
                 return True
             else:
                 on_hold.sort(key=lambda x: self.get_bundle_datetime(x['labels']['bundle-version']))
-                return workflow.bundle_version < self.get_bundle_datetime(on_hold[-1]['labels']['bundle-version'])
+                workflow_bundle_version = self.get_bundle_datetime(workflow.bundle_version)
+                return workflow_bundle_version < self.get_bundle_datetime(on_hold[-1]['labels']['bundle-version'])
         return False
 
     @staticmethod

--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -127,17 +127,31 @@ class Igniter(object):
             query_dict, self.cromwell_auth, raise_for_status=True
         )
         results = response.json()['results']
-        existing_workflows = [result for result in results if result['id'] != workflow.id]
+        existing_workflows = [
+            result for result in results if result['id'] != workflow.id
+        ]
         if len(existing_workflows) > 0:
             # If there are other on-hold workflows with the same hash-id,
             # the workflow is a duplicate/should not be run if it has an older bundle version than the others
-            on_hold = [workflow for workflow in existing_workflows if workflow['status'] == 'On Hold']
+            on_hold = [
+                workflow
+                for workflow in existing_workflows
+                if workflow['status'] == 'On Hold'
+            ]
             if len(on_hold) == 0:
                 return True
             else:
-                on_hold.sort(key=lambda x: self.get_bundle_datetime(x['labels']['bundle-version']))
-                workflow_bundle_version = self.get_bundle_datetime(workflow.bundle_version)
-                return workflow_bundle_version < self.get_bundle_datetime(on_hold[-1]['labels']['bundle-version'])
+                on_hold.sort(
+                    key=lambda x: self.get_bundle_datetime(
+                        x['labels']['bundle-version']
+                    )
+                )
+                workflow_bundle_version = self.get_bundle_datetime(
+                    workflow.bundle_version
+                )
+                return workflow_bundle_version < self.get_bundle_datetime(
+                    on_hold[-1]['labels']['bundle-version']
+                )
         return False
 
     @staticmethod

--- a/falcon/queue_handler.py
+++ b/falcon/queue_handler.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 from queue import Queue
 from threading import Thread, get_ident
+from copy import deepcopy
 
 import requests
 from cromwell_tools.cromwell_api import CromwellAPI
@@ -19,10 +20,15 @@ class Workflow(object):
     Besides the features for de-duplication, this class also utilizes a smaller size of chunk in memory.
     """
 
-    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None):
+    def __init__(self, workflow_id, bundle_uuid=None, bundle_version=None, labels=None):
+
         self.id = workflow_id
         self.bundle_uuid = bundle_uuid
         self.bundle_version = bundle_version
+        if labels is None:
+            self.labels = {}
+        else:
+            self.labels = deepcopy(labels)
 
     def __str__(self):
         return str(self.id)
@@ -287,9 +293,7 @@ class QueueHandler(object):
             Workflow: A concrete `Workflow` instance that has necessary properties.
         """
         workflow_id = workflow_meta.get('id')
-        workflow_labels = workflow_meta.get(
-            'labels'
-        )  # TODO: Integrate this field into Workflow class
+        workflow_labels = workflow_meta.get('labels')
         workflow_bundle_uuid = (
             workflow_labels.get('bundle-uuid')
             if isinstance(workflow_labels, dict)
@@ -300,7 +304,9 @@ class QueueHandler(object):
             if isinstance(workflow_labels, dict)
             else None
         )
-        workflow = Workflow(workflow_id, workflow_bundle_uuid, workflow_bundle_version)
+        workflow = Workflow(
+            workflow_id, workflow_bundle_uuid, workflow_bundle_version, workflow_labels
+        )
         return workflow
 
     @staticmethod

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -28,7 +28,7 @@ def query_workflows_succeed(query_dict, auth, raise_for_status=False):
     response.status_code = 200
     response.json.return_value = {
         'results': [
-            {'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'}
+            {'id': str(uuid4()), 'status': 'Succeeded', 'submission': '2018-05-25T19:03:51.736Z'}
             for i in range(random.randint(1, 10))
         ]
     }
@@ -40,7 +40,55 @@ def query_workflows_return_fake_workflow(query_dict, auth, raise_for_status=Fals
     response.status_code = 200
     response.json.return_value = {
         'results': [
+
             {'id': 'fake_workflow_id', 'submission': '2018-05-25T19:03:51.736Z'}
+        ]
+    }
+    return response
+
+
+def query_workflows_returns_on_hold_workflows_with_duplicate_bundle_versions(query_dict, auth, raise_for_status=False):
+    response = Mock(spec=Response)
+    response.status_code = 200
+    labels = {
+        'bundle-uuid': 'bundle_1',
+        'bundle-version': '2019-08-22T120000.000000Z',
+        'hash-id': '12345'
+    }
+    response.json.return_value = {
+        'results': [
+            {'id': 'fake_workflow_id_1', 'status': 'On Hold', 'submission': '2018-05-25T19:03:51.736Z', 'labels': labels},
+            {'id': 'fake_workflow_id_2', 'status': 'On Hold', 'submission': '2018-05-25T19:04:51.736Z', 'labels': labels}
+        ]
+    }
+    return response
+
+
+def query_workflows_returns_workflows_with_different_bundle_versions(query_dict, auth, raise_for_status=False):
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.json.return_value = {
+        'results': [
+            {
+                'id': 'fake_workflow_id_1',
+                'status': 'On Hold',
+                'submission': '2018-05-25T19:03:51.736Z',
+                'labels': {
+                    'bundle-uuid': 'bundle_1',
+                    'bundle-version': '2019-08-22T120000.000000Z',
+                    'hash-id': '12345'
+                }
+            },
+            {
+                'id': 'fake_workflow_id_2',
+                'status': 'On Hold',
+                'submission': '2018-05-25T19:04:51.736Z',
+                'labels': {
+                    'bundle-uuid': 'bundle_1',
+                    'bundle-version': '2019-08-22T130000.000000Z',
+                    'hash-id': '12345'
+                }
+            }
         ]
     }
     return response

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -23,13 +23,24 @@ def release_workflow_raises_RequestException(uuid, auth):
     raise requests.exceptions.RequestException
 
 
-def query_workflows_succeed(query_dict, auth):
+def query_workflows_succeed(query_dict, auth, raise_for_status=False):
     response = Mock(spec=Response)
     response.status_code = 200
     response.json.return_value = {
         'results': [
             {'id': str(uuid4()), 'submission': '2018-05-25T19:03:51.736Z'}
             for i in range(random.randint(1, 10))
+        ]
+    }
+    return response
+
+
+def query_workflows_return_fake_workflow(query_dict, auth, raise_for_status=False):
+    response = Mock(spec=Response)
+    response.status_code = 200
+    response.json.return_value = {
+        'results': [
+            {'id': 'fake_workflow_id', 'submission': '2018-05-25T19:03:51.736Z'}
         ]
     }
     return response

--- a/falcon/test/cromwell_simulator.py
+++ b/falcon/test/cromwell_simulator.py
@@ -28,7 +28,11 @@ def query_workflows_succeed(query_dict, auth, raise_for_status=False):
     response.status_code = 200
     response.json.return_value = {
         'results': [
-            {'id': str(uuid4()), 'status': 'Succeeded', 'submission': '2018-05-25T19:03:51.736Z'}
+            {
+                'id': str(uuid4()),
+                'status': 'Succeeded',
+                'submission': '2018-05-25T19:03:51.736Z',
+            }
             for i in range(random.randint(1, 10))
         ]
     }
@@ -40,31 +44,44 @@ def query_workflows_return_fake_workflow(query_dict, auth, raise_for_status=Fals
     response.status_code = 200
     response.json.return_value = {
         'results': [
-
             {'id': 'fake_workflow_id', 'submission': '2018-05-25T19:03:51.736Z'}
         ]
     }
     return response
 
 
-def query_workflows_returns_on_hold_workflows_with_duplicate_bundle_versions(query_dict, auth, raise_for_status=False):
+def query_workflows_returns_on_hold_workflows_with_duplicate_bundle_versions(
+    query_dict, auth, raise_for_status=False
+):
     response = Mock(spec=Response)
     response.status_code = 200
     labels = {
         'bundle-uuid': 'bundle_1',
         'bundle-version': '2019-08-22T120000.000000Z',
-        'hash-id': '12345'
+        'hash-id': '12345',
     }
     response.json.return_value = {
         'results': [
-            {'id': 'fake_workflow_id_1', 'status': 'On Hold', 'submission': '2018-05-25T19:03:51.736Z', 'labels': labels},
-            {'id': 'fake_workflow_id_2', 'status': 'On Hold', 'submission': '2018-05-25T19:04:51.736Z', 'labels': labels}
+            {
+                'id': 'fake_workflow_id_1',
+                'status': 'On Hold',
+                'submission': '2018-05-25T19:03:51.736Z',
+                'labels': labels,
+            },
+            {
+                'id': 'fake_workflow_id_2',
+                'status': 'On Hold',
+                'submission': '2018-05-25T19:04:51.736Z',
+                'labels': labels,
+            },
         ]
     }
     return response
 
 
-def query_workflows_returns_workflows_with_different_bundle_versions(query_dict, auth, raise_for_status=False):
+def query_workflows_returns_workflows_with_different_bundle_versions(
+    query_dict, auth, raise_for_status=False
+):
     response = Mock(spec=Response)
     response.status_code = 200
     response.json.return_value = {
@@ -76,8 +93,8 @@ def query_workflows_returns_workflows_with_different_bundle_versions(query_dict,
                 'labels': {
                     'bundle-uuid': 'bundle_1',
                     'bundle-version': '2019-08-22T120000.000000Z',
-                    'hash-id': '12345'
-                }
+                    'hash-id': '12345',
+                },
             },
             {
                 'id': 'fake_workflow_id_2',
@@ -86,9 +103,9 @@ def query_workflows_returns_workflows_with_different_bundle_versions(query_dict,
                 'labels': {
                     'bundle-uuid': 'bundle_1',
                     'bundle-version': '2019-08-22T130000.000000Z',
-                    'hash-id': '12345'
-                }
-            }
+                    'hash-id': '12345',
+                },
+            },
         ]
     }
     return response

--- a/falcon/test/test_igniters.py
+++ b/falcon/test/test_igniters.py
@@ -384,3 +384,67 @@ class TestIgniter(object):
             )
             is False
         )
+
+    @patch(
+        'falcon.igniter.CromwellAPI.query',
+        cromwell_simulator.query_workflows_returns_on_hold_workflows_with_duplicate_bundle_versions,
+        create=True,
+    )
+    def test_workflow_is_duplicate_handles_duplicate_bundle_version_in_queue(
+            self, caplog
+    ):
+        caplog.set_level(logging.INFO)
+        test_igniter = igniter.Igniter(self.config_path)
+        assert (
+            test_igniter.workflow_is_duplicate(
+                workflow=queue_handler.Workflow(
+                    'fake_workflow_id_1',
+                    bundle_version='2019-08-22T120000.000000Z',
+                    labels={'hash-id': '12345'}
+                )
+            )
+            is False
+        )
+
+    @patch(
+        'falcon.igniter.CromwellAPI.query',
+        cromwell_simulator.query_workflows_returns_workflows_with_different_bundle_versions,
+        create=True,
+    )
+    def test_workflow_is_duplicate_returns_true_if_newer_bundle_version_is_on_hold(
+            self, caplog
+    ):
+        caplog.set_level(logging.INFO)
+        test_igniter = igniter.Igniter(self.config_path)
+        assert (
+            test_igniter.workflow_is_duplicate(
+                workflow=queue_handler.Workflow(
+                    'fake_workflow_id_1',
+                    bundle_version='2019-08-22T120000.000000Z',
+                    labels={'hash-id': '12345'}
+                )
+            )
+            is True
+        )
+
+
+    @patch(
+        'falcon.igniter.CromwellAPI.query',
+        cromwell_simulator.query_workflows_returns_workflows_with_different_bundle_versions,
+        create=True,
+    )
+    def test_workflow_is_duplicate_returns_false_if_bundle_is_the_latest_version_on_hold(
+            self, caplog
+    ):
+        caplog.set_level(logging.INFO)
+        test_igniter = igniter.Igniter(self.config_path)
+        assert (
+            test_igniter.workflow_is_duplicate(
+                workflow=queue_handler.Workflow(
+                    'fake_workflow_id_2',
+                    bundle_version='2019-08-22T130000.000000Z',
+                    labels={'hash-id': '12345'}
+                )
+            )
+            is False
+        )

--- a/falcon/test/test_igniters.py
+++ b/falcon/test/test_igniters.py
@@ -391,7 +391,7 @@ class TestIgniter(object):
         create=True,
     )
     def test_workflow_is_duplicate_handles_duplicate_bundle_version_in_queue(
-            self, caplog
+        self, caplog
     ):
         caplog.set_level(logging.INFO)
         test_igniter = igniter.Igniter(self.config_path)
@@ -400,7 +400,7 @@ class TestIgniter(object):
                 workflow=queue_handler.Workflow(
                     'fake_workflow_id_1',
                     bundle_version='2019-08-22T120000.000000Z',
-                    labels={'hash-id': '12345'}
+                    labels={'hash-id': '12345'},
                 )
             )
             is False
@@ -412,7 +412,7 @@ class TestIgniter(object):
         create=True,
     )
     def test_workflow_is_duplicate_returns_true_if_newer_bundle_version_is_on_hold(
-            self, caplog
+        self, caplog
     ):
         caplog.set_level(logging.INFO)
         test_igniter = igniter.Igniter(self.config_path)
@@ -421,12 +421,11 @@ class TestIgniter(object):
                 workflow=queue_handler.Workflow(
                     'fake_workflow_id_1',
                     bundle_version='2019-08-22T120000.000000Z',
-                    labels={'hash-id': '12345'}
+                    labels={'hash-id': '12345'},
                 )
             )
             is True
         )
-
 
     @patch(
         'falcon.igniter.CromwellAPI.query',
@@ -434,7 +433,7 @@ class TestIgniter(object):
         create=True,
     )
     def test_workflow_is_duplicate_returns_false_if_bundle_is_the_latest_version_on_hold(
-            self, caplog
+        self, caplog
     ):
         caplog.set_level(logging.INFO)
         test_igniter = igniter.Igniter(self.config_path)
@@ -443,7 +442,7 @@ class TestIgniter(object):
                 workflow=queue_handler.Workflow(
                     'fake_workflow_id_2',
                     bundle_version='2019-08-22T130000.000000Z',
-                    labels={'hash-id': '12345'}
+                    labels={'hash-id': '12345'},
                 )
             )
             is False


### PR DESCRIPTION
### Purpose
If a new notification results in duplicate workflows, falcon should start one of them instead of aborting both. If there is a new workflow and an update workflow in the queue, falcon should start the update/latest one.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Updated `workflow_is_duplicate` function and added test cases.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
