### PR TITLE
Fix issue with de-dup logic

### DIFF
--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -123,10 +123,8 @@ class Igniter(object):
     def workflow_is_duplicate(self, workflow):
         hash_id = workflow.labels.get('hash-id')
         query_dict = {
-            'label': {
-                'hash-id': hash_id
-            },
-            'additionalQueryResultFields': 'labels'
+            'label': {'hash-id': hash_id},
+            'additionalQueryResultFields': 'labels',
         }
         response = CromwellAPI.query(
             query_dict, self.cromwell_auth, raise_for_status=True

--- a/falcon/igniter.py
+++ b/falcon/igniter.py
@@ -122,7 +122,12 @@ class Igniter(object):
 
     def workflow_is_duplicate(self, workflow):
         hash_id = workflow.labels.get('hash-id')
-        query_dict = {'label': f'hash-id:{hash_id}'}
+        query_dict = {
+            'label': {
+                'hash-id': hash_id
+            },
+            'additionalQueryResultFields': 'labels'
+        }
         response = CromwellAPI.query(
             query_dict, self.cromwell_auth, raise_for_status=True
         )


### PR DESCRIPTION
### Purpose
Include workflow labels in the query response when querying by hash-labels, otherwise Falcon will not be able to find the bundle-version.
